### PR TITLE
git_setup: Add default for merge options.

### DIFF
--- a/roles/git_setup/tasks/main.yml
+++ b/roles/git_setup/tasks/main.yml
@@ -59,3 +59,9 @@
     block: |
       GPG_TTY=$(tty)
       export GPG_TTY
+
+- name: Setup default merge behaviour
+  community.general.git_config:
+    name: pull.rebase
+    value: "false"
+    scope: global


### PR DESCRIPTION
Git reports a warning if the default merge behaviour is not set. So we explicitly set to the default behaviour to avoid this warning.