### PR TITLE
eideticom-scripts: Add a role to install eideticom-scripts

### DIFF
--- a/playbooks/setup-newmachine.yml
+++ b/playbooks/setup-newmachine.yml
@@ -19,6 +19,9 @@
     - role: "tmux_scripts"
       remote_user: batesste
       become: no
+    - role: "eideticom-scripts"
+      remote_user: batesste
+      become: no
     - role: "git_setup"
       remote_user: batesste
       become: no

--- a/roles/eideticom-scripts/tasks/main.yml
+++ b/roles/eideticom-scripts/tasks/main.yml
@@ -1,0 +1,34 @@
+# Copyright (c) Stephen Bates, 2022
+#
+# Set up the eideticom-scripts repo in ~/.bin/ folder and ensure that
+# folder is added to the user's path. See [1] for the repo for these
+# scripts and an explanation on what they do.
+#
+# [1]: https://github.com/Eideticom/eideticom-scripts
+
+- name: Create ~/.local/bin directory if it does not already exist
+  ansible.builtin.file:
+    path: /home/batesste/.local/bin
+    state: directory
+    owner: batesste
+    group: batesste
+    mode: "0755"
+
+- name: Checkout eideticom-scripts in the relevant folder. Update if needed.
+  ansible.builtin.git:
+    repo: git@github.com:Eideticom/eideticom-scripts.git
+    dest: ~/.local/bin/eideticom-scripts
+    accept_hostkey: yes
+    force: yes
+
+- name: Add a block to .bashrc that adds the ~/.bin folder to path.
+  ansible.builtin.blockinfile:
+    path: /home/batesste/.bashrc
+    owner: batesste
+    group: batesste
+    state: present
+    create: true
+    marker_begin: "BEGIN (eideticom-scripts)" 
+    marker_end: "END (eideticom-scripts)" 
+    block: |
+      export PATH="$HOME/.local/bin:$HOME/.local/bin/eideticom-scripts:$PATH"


### PR DESCRIPTION
eideticom-scripts is a repo that contains a bunch of useful tools so we install this and ensure the scripts are on our path.