### PR TITLE
.gitignore: Add an entry for the Ansible Vault password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # Ansible hosts file
 playbooks/hosts
+
+# Ansible vault password file
+playbooks/vault


### PR DESCRIPTION
To make scripting easier we sometimes want to place the ansible-vault password in a file as plain text. We certainly never want to check this file in so we add it to .gitignore.