### PR TITLE
aws-grub: Add a role to setup GRUB console on AWS machines

### DIFF
--- a/playbooks/setup-newmachine.yml
+++ b/playbooks/setup-newmachine.yml
@@ -41,3 +41,8 @@
       remote_user: "{{ username }}"
       become: no
       tags: [fio-devel]
+    - role: "aws-grub"
+      remote_user: "{{ username }}"
+      become: yes
+      tags: [aws-grub]
+      when: inventory_hostname in groups['awsmachines']

--- a/roles/aws-grub/README.md
+++ b/roles/aws-grub/README.md
@@ -1,0 +1,9 @@
+# aws-grub Ansible Role
+
+## Overview
+
+This role sets up [GRUB][grub] viewing on AWS instances. It follows
+the instructions that can be found [here][grub-inst].
+
+[grub]: https://www.gnu.org/software/grub/
+[grub-inst]:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/grub.html

--- a/roles/aws-grub/files/50-cloudimg-settings.cfg
+++ b/roles/aws-grub/files/50-cloudimg-settings.cfg
@@ -1,0 +1,18 @@
+# Cloud Image specific Grub settings for Generic Cloud Images
+# CLOUD_IMG: This file was created/modified by the Cloud Image build process
+
+# Note installed by batesste-ansible (aws-grub role)
+
+# Set the recordfail timeout
+GRUB_RECORDFAIL_TIMEOUT=0
+
+# Do not wait on grub prompt
+GRUB_TIMEOUT=1
+GRUB_TIMEOUT_STYLE=menu
+
+# Set the default commandline
+GRUB_CMDLINE_LINUX_DEFAULT="console=tty1 console=ttyS0 nvme_core.io_timeout=4294967295"
+
+# Set the grub console type
+GRUB_TERMINAL="console serial"
+GRUB_SERIAL_COMMAND="serial --speed 115200"

--- a/roles/aws-grub/tasks/main.yml
+++ b/roles/aws-grub/tasks/main.yml
@@ -1,0 +1,18 @@
+# Copyright (c) Stephen Bates, 2022
+#
+# Set up grub on AWS instances.
+#
+# See this Role's README.md for more information.
+#
+
+- name: Copy grub settings for AWS console access
+  ansible.builtin.copy:
+    src: 50-cloudimg-settings.cfg
+    dest: /etc/default/grub.d/
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Update grub
+  ansible.builtin.shell:
+    cmd: update-grub


### PR DESCRIPTION
It can be useful to view the serial console when booting EC2 instances. This role sets up the EC2 instance to allow that.

Fixes #15.