### PR TITLE
user-setup: Add task to enable user access to dmesg

### DIFF
--- a/roles/user-setup/tasks/main.yml
+++ b/roles/user-setup/tasks/main.yml
@@ -53,3 +53,17 @@
     dest: /home/{{ username }}/.ssh/id_rsa.pub
     owner: "{{ username }}"
     group: "{{ username }}"
+
+- name: Ensure users can access dmesg without sudo
+  ansible.builtin.blockinfile:
+    path: /etc/sysctl.d/10-kernel-hardening.conf
+    state: present
+    create: false
+    marker_begin: "BEGIN (user-setup)"
+    marker_end: "END (user-setup)"
+    block: |
+      kernel.dmesg_restrict = 0
+
+- name: Restart procps service so dmesg rule takes effect
+  ansible.builtin.shell:
+    cmd: service procps restart


### PR DESCRIPTION
Ubuntu now prevents user access to dmesg by default for security reasons. We do not need to be that strict and some of my tmux stuff likes being able to access dmesg without needing sudo. So lets remove this restriction.

Fixes #23.