### PR TITLE
mutt-setup: Fix name of marker in role.

### DIFF
--- a/roles/mutt-setup/tasks/main.yml
+++ b/roles/mutt-setup/tasks/main.yml
@@ -154,8 +154,8 @@
     group: "{{ username }}"
     state: present
     create: true
-    marker_begin: "BEGIN (mutt_setup)" 
-    marker_end: "END (mutt_setup)" 
+    marker_begin: "BEGIN (mutt-setup)"
+    marker_end: "END (mutt-setup)"
     block: |
       EMAIL=sbates@raithlin.com
       export EMAIL


### PR DESCRIPTION
In one of the roles we use _ rather than - for the block marker. Fix this small issue.