### PR TITLE
kernel-setup: Clean this up and remove the cloning

### DIFF
--- a/roles/kernel-setup/defaults/main.yml
+++ b/roles/kernel-setup/defaults/main.yml
@@ -1,16 +1,13 @@
 # Copyright (c) Stephen Bates, 2022
 
-# Do we clone the Linux kernel (takes up space and time). If not we just init and setup remotes.
-clone: false
+# Do we update when we install packages
+update_cache: no
 
-# Location of kernel.org script used to accelerate initial clone
-clone_script: https://git.kernel.org/pub/scm/linux/kernel/git/mricon/korg-helpers.git/plain/linux-bundle-clone
+# Do we force a clean setup?
+force: false
 
 # Linus Remote
 linus_remote: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 
 # Stable Remote
 stable_remote: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git
-
-# Branch to checkout
-branch_checkout: master

--- a/roles/kernel-setup/tasks/main.yml
+++ b/roles/kernel-setup/tasks/main.yml
@@ -1,7 +1,18 @@
 # Copyright (c) Stephen Bates, 2022
 #
-# Clone and update for Linux kernel development. Note we can checkout
-# the Linux repo but only if the clone variable is set to true.
+# Update for Linux kernel development. Note we setup the linux kernel
+# remotes but do not fetch or clone as this takes a long time. The user
+# can do this later
+
+- name: Install kernel build pre-requisites and update if requested
+  ansible.builtin.package:
+    update_cache: "{{ update_cache }}"
+    name:
+      - bison
+      - flex
+      - libelf-dev
+      - libssl-dev
+  become: yes
 
 - name: Checkout kernel-tools repo
   ansible.builtin.git:
@@ -10,54 +21,41 @@
     accept_hostkey: yes
     force: yes
 
-- name: Create a kernel source folder when not cloning
+- name: Remove the src folder when forcing
+  ansible.builtin.file:
+    path: ~/kernel/src
+    state: absent
+  when: force|bool
+
+- name: Ensure a kernel source exists
   ansible.builtin.file:
     path: ~/kernel/src
     state: directory
     owner: "{{ username }}"
     group: "{{ username }}"
     mode: "0755"
-  when: not clone
 
-- name: Ensure no kernel source folder when cloning
-  ansible.builtin.file:
-    path: ~/kernel/src
-    state: absent
-  when: clone
-
-- name: Copy over the Linux kernel git bundle script when cloning
-  ansible.builtin.get_url:
-    url: '{{ clone_script }}'
-    dest: /tmp/linux-bundle-clone
-    owner: "{{ username }}"
-    group: "{{ username }}"
-    mode: "0775"
-  when: clone
-
-- name: Clone the Linux kernel Linus repo (if it has not already been cloned) via git bundle (slow!!)
-  ansible.builtin.command:
-    chdir: ~/kernel
-    cmd: /tmp/linux-bundle-clone '{{ linus_remote }}' src '{{ branch_checkout }}'
-    creates: ~/kernel/src/MAINTAINERS
-  when: clone
-
-- name: Perform a git init in source folder when not cloning
+- name: Perform a git init in source folder
   ansible.builtin.shell:
     cmd: git init
     chdir: ~/kernel/src
-  when: not clone
 
-- name: Ensure linus remote is added when not cloning
+- name: Ensure remotes are added
   git_config:
-        repo: ~/kernel/src/
-        scope: 'local'
-        name: 'remote.linus.url'
-        value: '{{ linus_remote }}'
-  when: not clone
+    repo: ~/kernel/src/
+    scope: 'local'
+    name: 'remote.{{ item.name }}.url'
+    value: '{{ item.remote }}'
+  loop:
+    - { name: 'linus', remote: "{{ linus_remote }}" }
+    - { name: 'stable', remote: "{{ stable_remote }}" }
 
-- name: Ensure stable remote is added
+- name: Ensure fetching gets all branches
   git_config:
-        repo: ~/kernel/src/
-        scope: 'local'
-        name: 'remote.stable.url'
-        value: '{{ stable_remote }}'
+    repo: ~/kernel/src/
+    scope: 'local'
+    name: 'remote.{{ item }}.fetch'
+    value: "+refs/heads/*:refs/remotes/{{ item }}/*"
+  loop:
+    - linus
+    - stable


### PR DESCRIPTION
The cloning of the linux kernel takes too long to be a reasonable Ansible task. So we change this to setup for kernel development but leave the fetches and clones to the user at a later date.