### PR TITLE
Projects: Put code into a Projects folder

### DIFF
--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Render the checkout directory safe for the lint step
         run: git config --global --add safe.directory /github/workspace
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@main
+        uses: ansible-community/ansible-lint-action@v6.8.2
       - name: Create an SSH keypair
         run: mkdir -p .ssh && ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ""
       - name: Create a GNU PGP folder

--- a/roles/fio-devel/handlers/main.yml
+++ b/roles/fio-devel/handlers/main.yml
@@ -1,18 +1,18 @@
 ---
 - name: Configure fio
   ansible.builtin.command:
-    chdir: ~/fio
+    chdir: ~/Projects/fio
     cmd: ./configure --prefix='{{ fio_install_dir }}'
   listen: Configure, build and install fio
   notify: Make fio
 
 - name: Make fio
   ansible.builtin.shell:
-    chdir: ~/fio
+    chdir: ~/Projects/fio
     cmd: make -j $(nproc)
   notify: Install fio
 
 - name: Install fio
   ansible.builtin.command:
-    cmd: make -C /home/{{ username }}/fio install
+    cmd: make -C /home/{{ username }}/Projects/fio install
   become: true

--- a/roles/fio-devel/tasks/main.yml
+++ b/roles/fio-devel/tasks/main.yml
@@ -35,10 +35,16 @@
   become: true
   when: inventory_hostname in groups['awsmachines']
 
+- name: Ensure Projects folder exists.
+  ansible.builtin.file:
+    path: ~/Projects
+    state: directory
+    mode: "0755"
+
 - name: Checkout upstream fio repo from Github
   ansible.builtin.git:
     repo: https://github.com/axboe/fio.git
-    dest: ~/fio
+    dest: ~/Projects/fio
     force: true
     version: "{{ fio_tag }}"
   notify: Configure, build and install fio

--- a/roles/kernel-setup/tasks/main.yml
+++ b/roles/kernel-setup/tasks/main.yml
@@ -17,35 +17,41 @@
       - libssl-dev
   become: true
 
+- name: Ensure Projects folder exists.
+  ansible.builtin.file:
+    path: ~/Projects
+    state: directory
+    mode: "0755"
+
 - name: Checkout kernel-tools repo
   ansible.builtin.git:
     repo: "{{ (username == 'batesste') | ternary('git@github.com:sbates130272/kernel-tools.git', 'https://github.com/sbates130272/kernel-tools.git') }}"
-    dest: ~/kernel
+    dest: ~/Projects/kernel
     accept_hostkey: true
     force: true
     version: "{{ kernel_setup_tools_sha }}"
 
 - name: Remove the src folder when forcing
   ansible.builtin.file:
-    path: ~/kernel/src
+    path: ~/Projects/kernel/src
     state: absent
   when: kernel_setup_force|bool
 
 - name: Ensure a kernel source exists
   ansible.builtin.file:
-    path: ~/kernel/src
+    path: ~/Projects/kernel/src
     state: directory
     mode: "0755"
 
 - name: Perform a git init in source folder
   ansible.builtin.command:
     cmd: git init
-    chdir: ~/kernel/src
+    chdir: ~/Projects/kernel/src
     creates: ~/kernel/src/.git
 
 - name: Ensure remotes are added
   community.general.git_config:
-    repo: ~/kernel/src/
+    repo: ~/Projects/kernel/src/
     scope: local
     name: remote.{{ item.name }}.url
     value: "{{ item.remote }}"
@@ -55,7 +61,7 @@
 
 - name: Ensure fetching gets all branches
   community.general.git_config:
-    repo: ~/kernel/src/
+    repo: ~/Projects/kernel/src/
     scope: local
     name: remote.{{ item }}.fetch
     value: +refs/heads/*:refs/remotes/{{ item }}/*


### PR DESCRIPTION
It is cleaner to populate a top-level Projects folder and so we do this for relevant roles.

Fixes #34.