### PR TITLE
fio-stuff: Add the fio-stuff repo to the fio_devel role

### DIFF
--- a/roles/fio_devel/defaults/main.yml
+++ b/roles/fio_devel/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
-# fio tag to checkout
-fio_tag: HEAD
+# fio tag/sha to checkout
+fio_devel_fio_sha: db7fc8d864dc4fb607a0379333a0db60431bd649
 
 # fio install folder
-fio_install_dir: /opt/fio
+fio_devel_fio_install_dir: /opt/fio
+
+# fio-stuff tag/sha to checkout
+fio_devel_fio_stuff_sha: a0e9fcd99dc2793badd04cd2b387aeafa3ec35ea

--- a/roles/fio_devel/handlers/main.yml
+++ b/roles/fio_devel/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: Configure fio
   ansible.builtin.command:
     chdir: ~/Projects/fio
-    cmd: ./configure --prefix='{{ fio_install_dir }}'
+    cmd: ./configure --prefix='{{ fio_devel_fio_install_dir }}'
   listen: Configure, build and install fio
   notify: Make fio
 

--- a/roles/fio_devel/tasks/main.yml
+++ b/roles/fio_devel/tasks/main.yml
@@ -4,7 +4,8 @@
 # Clone the upstream fio repo from Jens and checkout the SHA given by
 # the associated input variable. Also ensure the packages required to
 # run specific tests are included and also update this version of fio
-# to the PATH.
+# to the PATH. Also install the fio-stuff repo which has some useful
+# tools in it.
 
 - name: Install fio related packages
   ansible.builtin.package:
@@ -46,5 +47,13 @@
     repo: https://github.com/axboe/fio.git
     dest: ~/Projects/fio
     force: true
-    version: "{{ fio_tag }}"
+    version: "{{ fio_devel_fio_sha }}"
   notify: Configure, build and install fio
+
+- name: Checkout fio-stuff repo
+  ansible.builtin.git:
+    repo: "{{ (username == 'batesste') | ternary('git@github.com:sbates130272/fio-stuff.git', 'https://github.com/sbates130272/fio-stuff.git') }}"
+    dest: ~/Projects/fio-stuff
+    accept_hostkey: true
+    force: true
+    version: "{{ fio_devel_fio_stuff_sha }}"


### PR DESCRIPTION
The fio-stuff repo is full of useful things so let's add that to the fio_devel role. Also clean up the fio_devel role a little.

Fixes #42.