### PR TITLE
netplan: Fix waiting for interface issue

### DIFF
--- a/roles/user_setup/tasks/main.yml
+++ b/roles/user_setup/tasks/main.yml
@@ -71,3 +71,14 @@
   ansible.builtin.service:
     service: procps
     state: restarted
+
+- name: Massively improve startup on certain systems
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service
+    search_string: ExecStart
+    line: ExecStart=/lib/systemd/systemd-networkd-wait-online --any
+
+- name: Restart service
+  ansible.builtin.service:
+    service: network-online.target
+    state: restarted


### PR DESCRIPTION
On some systems, especially those with more than one network interface, it makes sense to just wait for any interface to come online rather than all of them.

Fixes #26.