### PR TITLE
python2: Add symbolic link

### DIFF
--- a/roles/fave_packages/tasks/main.yml
+++ b/roles/fave_packages/tasks/main.yml
@@ -13,6 +13,7 @@
       - emacs-nox
       - fio
       - git
+      - gnuplot
       - gpg-agent
       - libaio-dev
       - liburing-dev
@@ -22,3 +23,9 @@
       - sysstat
       - tree
     state: present
+
+- name: Symbolic link from python2 to python
+  ansible.builtin.file:
+    src: /usr/bin/python2
+    path: /usr/bin/python
+    state: link


### PR DESCRIPTION
Create a symbolic link to tie python to python2. While we are at it let's add gnuplot to our favourite packages.