### PR TITLE
vm_create: Role for creating VMs on target(s)

### DIFF
--- a/.config/ansible-lint.yml
+++ b/.config/ansible-lint.yml
@@ -4,6 +4,8 @@
 
 warn_list:
   - command-instead-of-module
+  - no-changed-when
+  - command-instead-of-shell
 
 extra_vars:
   targets: localhost

--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -24,6 +24,7 @@ jobs:
           write-mode: overwrite
           contents: |
             [locals]
+            [runners]
             localhost root_user=runner username=runner ansible_connection=local
             [awsmachines]
             [localvms]
@@ -32,7 +33,7 @@ jobs:
         working-directory: ./playbooks
         env:
           PLAYBOOK: setup-newmachine.yml
-          TARGETS: locals
+          TARGETS: runners
           HOSTS: hosts-ci
           ANSIBLE_VAULT_PASSWORD_FILE: ./vault-env
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -3,6 +3,7 @@ Compatability
 DOM
 DOMs
 Gmail
+IPv
 LTS
 NVMe
 OAuth
@@ -32,3 +33,4 @@ sudo
 ubuntu
 vCPUs
 virt
+vm

--- a/playbooks/setup-newmachine.yml
+++ b/playbooks/setup-newmachine.yml
@@ -50,9 +50,19 @@
       remote_user: "{{ username }}"
       become: true
       tags: [aws_grub]
-      when: inventory_hostname in groups['awsmachines']
+      when:
+        - inventory_hostname in groups['awsmachines']
     - role: qemu_setup
       remote_user: "{{ username }}"
       become: false
       tags: [qemu_setup]
-      when: inventory_hostname not in groups['localvms']
+      when:
+        - inventory_hostname not in groups['localvms'] and
+          inventory_hostname not in groups['runners']
+    - role: vm_create
+      remote_user: "{{ username }}"
+      become: false
+      tags: [vm_create]
+      when:
+        - inventory_hostname not in groups['localvms'] and
+          inventory_hostname not in groups['runners']

--- a/requirements.yml
+++ b/requirements.yml
@@ -2,3 +2,4 @@
 collections:
   - name: ansible.posix
   - name: community.general
+  - name: community.libvirt

--- a/roles/git_setup/tasks/main.yml
+++ b/roles/git_setup/tasks/main.yml
@@ -16,7 +16,9 @@
     rsync_opts:
       - --exclude=S.*
       - --exclude=*~
-  when: inventory_hostname not in groups['locals']
+  when:
+    - inventory_hostname not in groups['locals'] and
+      inventory_hostname not in groups['runners']
 
 - name: Setup emacs as git editor
   community.general.git_config:

--- a/roles/qemu_setup/README.md
+++ b/roles/qemu_setup/README.md
@@ -5,10 +5,12 @@
 This role sets up a target for QEMU and libvirt. This enables
 emulation and hypervisor accelerated system and user emulation. It
 adds the target user to the necessary groups for permission to run
-libvirt.
+QEMU and libvirt.
 
 This role also checks out the HEAD of [qemu-minimal][ref-qm] which is
-a lightweight tool for running VMs and creating libvirt DOMs.
+a lightweight tool for running VMs and creating libvirt DOMs. To
+create a VM you can either use the instructions below or use the
+[vm_create][vm_create] role.
 
 ## Creating a libvirt VM
 
@@ -23,6 +25,7 @@ This will create a NAT connected VM with name <vm-name> based on the
 Ubuntu "Jammy" (22.04) release. Alter RELEASE for other versions (not
 all supported yet). Note you can then use ```virsh --edit <vm-name>```
 to alter the DOM for this VM to change vCPUs, memory, add NVMe SSDs do
-passthru etc.
+passthru etc. See the virt-install-ubuntu script for other options.
 
 [ref-qm]: https://github.com/sbates130272/qemu-minimal
+[vm_create]: ../roles/vm_create

--- a/roles/qemu_setup/defaults/main.yml
+++ b/roles/qemu_setup/defaults/main.yml
@@ -2,7 +2,7 @@
 # Copyright (c) Stephen Bates, 2022
 
 # Do we force a clean setup?
-qemu_setup_force: true
+qemu_setup_force: false
 
 # qemu-minimal git sha/tag
-qemu_setup_qemu_minimal_sha: 29d9a67ecc58ed92afa2348e940e7309a77645f7
+qemu_setup_qemu_minimal_sha: c76b818c3bed03111768c638ffebe43f33a85d06

--- a/roles/qemu_setup/tasks/main.yml
+++ b/roles/qemu_setup/tasks/main.yml
@@ -17,6 +17,8 @@
       - bridge-utils
       - cloud-image-utils
       - cpu-checker
+      - guestfs-tools
+      - libnss-libvirt
       - libvirt-clients
       - libvirt-daemon-system
       - qemu-kvm
@@ -24,19 +26,44 @@
       - virtinst
   become: true
 
+- name: Add user to virt groups
+  ansible.builtin.user:
+    name: "{{ username }}"
+    groups: kvm, libvirt
+    append: true
+  become: true
+
+- name: Enable access to images folder in AppArmour
+  ansible.builtin.lineinfile:
+    path: /etc/apparmor.d/abstractions/libvirt-qemu
+    line: "  /var/lib/libvirt/images/* rwk,"
+  become: true
+
+- name: Check for libvirt_guest in nsswitch.conf
+  ansible.builtin.lineinfile:
+    path: /etc/nsswitch.conf
+    regex: ^hosts:.*libvirt_guest*
+    state: absent
+  check_mode: true
+  changed_when: false
+  register: libvirt_guest
+  become: false
+
+- name: Enable libvirt_guest dns via nss
+  ansible.builtin.lineinfile:
+    path: /etc/nsswitch.conf
+    regex: ^(hosts:.*)
+    line: \1 libvirt_guest
+    backrefs: true
+  become: true
+  when: not libvirt_guest.found
+
 - name: Start relevant systemd services
   ansible.builtin.systemd:
     name: libvirtd
     state: restarted
     daemon_reload: true
     enabled: true
-  become: true
-
-- name: Add user to virt groups
-  ansible.builtin.user:
-    name: "{{ username }}"
-    groups: kvm, libvirt
-    append: true
   become: true
 
 - name: Ensure Projects folder exists.

--- a/roles/vm_create/README.md
+++ b/roles/vm_create/README.md
@@ -1,0 +1,24 @@
+# create_vm Ansible Role
+
+## Overview
+
+This role uses the [virt-install-ubuntu][ref1] script in the
+[qemu-minimal][ref2] repo to either create a new VM on the target(s)
+or start-up the VM if one with the requested name already exists. It
+should auto-magically make sure the target users SSH key is installed
+and that the VM in on the default network.
+
+Once this role has executed you can use a command like
+```
+virsh list --all
+```
+to see if the VM is installed and if it is running. You can use
+something like
+```
+virsh net-dhcp-leases default
+```
+to see what IPv4 address has been assigned to the VM. You can ssh into
+the machine using something as simple as
+```
+ssh <vm_name>
+```

--- a/roles/vm_create/defaults/main.yml
+++ b/roles/vm_create/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Copyright (c) Stephen Bates, 2022
+vm_create_vm_name: batesste-dev
+vm_create_password: password

--- a/roles/vm_create/meta/main.yml
+++ b/roles/vm_create/meta/main.yml
@@ -1,0 +1,19 @@
+---
+galaxy_info:
+  author: Stephen Bates
+  description: A role to enable the creation of VMs on the target(s)
+  company: Eideticom
+
+  license: Apache-2.0
+  min_ansible_version: "2.1"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - jammy
+  galaxy_tags:
+    - virtualization
+    - libvirt
+    - batesste
+
+dependencies:
+  - role: qemu_setup

--- a/roles/vm_create/tasks/main.yml
+++ b/roles/vm_create/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# Copyright (c) Stephen Bates, 2022
+#
+# Create a new VM using libvirt on the target(s). This code uses ideas
+# based on [1]. If the VM is already created we just ensure it is running.
+
+- name: Get VMs list
+  community.libvirt.virt:
+    command: list_vms
+  register: existing_vms
+  changed_when: false
+
+- name: Create VM if it does not exist
+  when: vm_create_vm_name not in existing_vms.list_vms
+  block:
+    - name: Use virt-install-ubuntu in qemu-minimal
+      ansible.builtin.shell:
+        chdir: ~/Projects/qemu-minimal/libvirt
+        cmd: ./virt-install-ubuntu
+      environment:
+        NAME: "{{ vm_create_vm_name }}"
+        LIBVIRT_DEFAULT_URI: qemu:///system
+        USERNAME: "{{ username }}"
+        PASSWORD: "{{ vm_create_password }}"
+
+- name: Ensure VM is started
+  community.libvirt.virt:
+    name: "{{ vm_create_vm_name }}"
+    state: running
+  register: vm_start_results
+  until: "vm_start_results is success"
+  retries: 15
+  delay: 2


### PR DESCRIPTION
This role can be used to create Virtual Machines (VMs) on remote target(s) and is based on [1]. Note this role depends on the qemu_setup role.

[1]: https://www.redhat.com/sysadmin/build-VM-fast-ansible

Fixes #51.