### PR TITLE
user_setup: Add timezone support

### DIFF
--- a/roles/user_setup/defaults/main.yml
+++ b/roles/user_setup/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # the default user is batesste
 username: batesste
+user_setup_timezone: Canada/Mountain

--- a/roles/user_setup/tasks/main.yml
+++ b/roles/user_setup/tasks/main.yml
@@ -91,3 +91,7 @@
     marker_end: END (user_setup)
     block: |
       export DEBIAN_FRONTEND=noninteractive
+
+- name: Set the timezone of the system clock
+  community.general.timezone:
+    name: "{{ user_setup_timezone }}"


### PR DESCRIPTION
Add a task to set the timezone on the target(s). There is a default that can be changed in the usual ways.

Fixes #55.