### PR TITLE
docker_setup: Add a role for installing docker

### DIFF
--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -11,6 +11,8 @@ jobs:
         uses: rojopolis/spellcheck-github-actions@0.27.0
       - name: Render the checkout directory safe for the lint step
         run: git config --global --add safe.directory /github/workspace
+      - name: Run ansible-galaxy to install collections and roles
+        run: ansible-galaxy install -r requirements.yml
       - name: Run ansible-lint
         uses: ansible-community/ansible-lint-action@v6.8.2
       - name: Create an SSH keypair

--- a/playbooks/ansible.cfg
+++ b/playbooks/ansible.cfg
@@ -1,2 +1,2 @@
 [defaults]
-roles_path = ../roles
+roles_path = ~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles:../roles

--- a/playbooks/setup-newmachine.yml
+++ b/playbooks/setup-newmachine.yml
@@ -8,7 +8,7 @@
 
 - name: Setup user account and install cool stuff on a new machine
   hosts: "{{ targets }}"
-  gather_facts: false
+  gather_facts: true
   roles:
     - role: user_setup
       remote_user: "{{ root_user }}"
@@ -46,6 +46,12 @@
       remote_user: "{{ username }}"
       become: false
       tags: [fio_devel]
+    - role: geerlingguy.docker
+      docker_edition: 'ce'
+      docker_users:
+        - "{{ username }}"
+      become: true
+      tags: [docker_setup]
     - role: aws_grub
       remote_user: "{{ username }}"
       become: true

--- a/requirements.yml
+++ b/requirements.yml
@@ -3,3 +3,6 @@ collections:
   - name: ansible.posix
   - name: community.general
   - name: community.libvirt
+
+roles:
+  - name: geerlingguy.docker


### PR DESCRIPTION
We use an existing ansible-galaxy role [1] to install docker on the target(s). Also sets up the user as a docker user.

Fixes #57.