### PR TITLE
qemu_setup: Add support for bridge creation libvirt networking.

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -6,3 +6,4 @@ collections:
 
 roles:
   - name: geerlingguy.docker
+  - name: mrlesmithjr.netplan

--- a/roles/qemu_setup/defaults/main.yml
+++ b/roles/qemu_setup/defaults/main.yml
@@ -5,4 +5,10 @@
 qemu_setup_force: false
 
 # qemu-minimal git sha/tag
-qemu_setup_qemu_minimal_sha: 15886c9b9b2c672819444215b8ae711d98527210
+qemu_setup_qemu_minimal_sha: 6c912a05d64611df53a832a3b88add7a8c46615b
+
+# Default bridge network settings
+qemu_setup_bridge: true
+qemu_setup_bridge_name: batesste-br0
+qemu_setup_bridge_iface: enp1s0
+qemu_setup_bridge_address: 10.0.0.55/24

--- a/roles/qemu_setup/tasks/main.yml
+++ b/roles/qemu_setup/tasks/main.yml
@@ -83,3 +83,22 @@
   failed_when:
     - repo_clone.failed
     - not 'Local modifications exist in the destination' in repo_clone.msg
+
+- name: Install network bridge if needed
+  ansible.builtin.include_role:
+    name:
+      mrlesmithjr.netplan
+  vars:
+    netplan_enabled: true
+    netplan_remove_existing: false
+    netplan_config_file: /etc/netplan/13-batesste-ansible-libvirt-netplan.yaml
+    netplan_configuration:
+      network:
+        version: 2
+        bridges:
+          "{{ qemu_setup_bridge_name }}":
+          dhcp4: false
+          addresses: '[ "{{ qemu_setup_bridge_address }}" ]'
+          interfaces: '[ "{{ qemu_setup_bridge_iface }}" ]'
+    become: true
+  when: qemu_setup_bridge


### PR DESCRIPTION
Update the qemu_setup role to add the optional creation of a network bridge on the target(s). This allows for VMs to either be added to the default NAT or to the bridge. When added to the bridge the VM appears as a new host on the LAN and can be accessed as such.

Resolves #70.