### PR TITLE
ansible-lint: Clean up how we call ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,6 +2,9 @@
 # .ansible-lint
 # See https://ansible-lint.readthedocs.io/configuring/
 
+exclude_paths:
+  - .github
+
 warn_list:
   - command-instead-of-module
   - no-changed-when

--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Run ansible-galaxy to install collections and roles
         run: ansible-galaxy install -r requirements.yml
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@v6.8.2
+        uses: ansible-community/ansible-lint-action@v6.17.0
       - name: Create an SSH keypair
         run: mkdir -p .ssh && ssh-keygen -b 2048 -t rsa -f ~/.ssh/id_rsa -q -N ""
       - name: Create a GNU PGP folder

--- a/roles/qemu_setup/tasks/main.yml
+++ b/roles/qemu_setup/tasks/main.yml
@@ -100,5 +100,5 @@
           dhcp4: false
           addresses: '[ "{{ qemu_setup_bridge_address }}" ]'
           interfaces: '[ "{{ qemu_setup_bridge_iface }}" ]'
-    become: true
+    ansible_become: true
   when: qemu_setup_bridge


### PR DESCRIPTION
We do not need an entire top-level folder. Also the newer version of ansible-lint added a new warning. We also update the github action version to latest.