### PR TITLE
fave_packages: Make python3 the default python

### DIFF
--- a/roles/fave_packages/tasks/main.yml
+++ b/roles/fave_packages/tasks/main.yml
@@ -19,6 +19,7 @@
       - liburing-dev
       - prometheus-node-exporter
       - prometheus-node-exporter-collectors
+      - python-is-python3
       - python2
       - python3-pip
       - mutt
@@ -27,9 +28,3 @@
       - tree
       - xfsprogs
     state: present
-
-- name: Symbolic link from python2 to python
-  ansible.builtin.file:
-    src: /usr/bin/python2
-    path: /usr/bin/python
-    state: link


### PR DESCRIPTION
In fave_packages we create a symbolic link to make Python2 the default python. However there are two bad things here:

  1. packages exist to do this sort of thing. Use one of these and not a hard coded thing.
  2. python3 is where it is at in this day and age.

Fixes #76.