### PR TITLE
eideticom: Remove references to the Eideticom stuff

### DIFF
--- a/playbooks/setup-newmachine.yml
+++ b/playbooks/setup-newmachine.yml
@@ -13,7 +13,6 @@
     force: false
     kernel_setup_force: "{{ force }}"
     kernel_setup_tools_force: "{{ force }}"
-    eideticom_scripts_force: "{{ force }}"
     qemu_setup_force: "{{ force }}"
     tmux_scripts_force: "{{ force }}"
     fio_devel_fio_force: "{{ force }}"
@@ -35,10 +34,6 @@
       remote_user: "{{ username }}"
       become: false
       tags: [tmux_scripts]
-    - role: eideticom_scripts
-      remote_user: "{{ username }}"
-      become: false
-      tags: [eideticom_scripts]
     - role: cloud_setup
       remote_user: "{{ username }}"
       become: false


### PR DESCRIPTION
Now I am no longer at Eideticom I should remmove the relevant role from my catch-all playbook. It won't run anyway as I no longer have access to those repos.