### PR TITLE
Updated spellcheck to contemporary version

### DIFF
--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install pip packages
         run: python3 -m pip install -r requirements.txt
       - name: GitHub spellcheck action
-        uses: rojopolis/spellcheck-github-actions@0.27.0
+        uses: rojopolis/spellcheck-github-actions@0.44.0
       - name: Render the checkout directory safe for the lint step
         run: git config --global --add safe.directory /github/workspace
       - name: Run ansible-galaxy to install collections and roles


### PR DESCRIPTION
Hello

As the maintainer of the [spellcheck GitHub action](https://github.com/marketplace/actions/github-spellcheck-action) I am sunsetting the used version as by the proposed [sunset policy](https://github.com/rojopolis/spellcheck-github-actions/wiki#sunset-policy)

I just updated the action to the latest version, alternatively you can alter the code to point to `v0` which is a canonical version. I do not use this approach myself if I can avoid it, but it is widely used for GitHub Actions.

Let me know if you have any issues with the proposed PR and I will do my best to accommodate.

I can recommend [Dependabot](https://github.com/dependabot) for keeping your GitHub actions up to date, alternatively there are [Renovate](https://github.com/marketplace/renovate), if you want a PR proposing a basic configuration for Dependabot, please let me know.

jonasbn
