### PR TITLE
docker.io: Replace docker-ce with docker.io

### DIFF
--- a/playbooks/setup-newmachine.yml
+++ b/playbooks/setup-newmachine.yml
@@ -60,12 +60,6 @@
       remote_user: "{{ username }}"
       become: false
       tags: [fio_devel]
-    - role: geerlingguy.docker
-      docker_edition: 'ce'
-      docker_users:
-        - "{{ username }}"
-      become: true
-      tags: [docker_setup]
     - role: aws_grub
       remote_user: "{{ username }}"
       become: true

--- a/roles/fave_packages/tasks/main.yml
+++ b/roles/fave_packages/tasks/main.yml
@@ -20,6 +20,7 @@
     name:
       - bmon
       - build-essential
+      - docker.io
       - emacs-nox
       - fio
       - git


### PR DESCRIPTION
It is preferable that we use the Debian maintained docker.io package rather then the docker provided docker.ce.

Fixes #81.