### PR TITLE
git_setup: Fix copying of conf files for gnupgp

### DIFF
--- a/roles/git_setup/tasks/main.yml
+++ b/roles/git_setup/tasks/main.yml
@@ -26,6 +26,7 @@
     rsync_opts:
       - --exclude=S.*
       - --exclude=*~
+      - --exclude=*.conf
   when:
     - inventory_hostname not in groups['locals'] and
       inventory_hostname not in groups['runners']


### PR DESCRIPTION
There is an issue when we copy the PGP configuration files from Mac as the pinentry program is wrong. So skip those files.

Fixes #98.