### PR TITLE
fave_packages/git-email: Add the git-email package.

### DIFF
--- a/roles/fave_packages/tasks/main.yml
+++ b/roles/fave_packages/tasks/main.yml
@@ -23,6 +23,7 @@
       - emacs-nox
       - fio
       - git
+      - git-email
       - gnuplot
       - gpg-agent
       - libaio-dev


### PR DESCRIPTION
In order to send email patches easily we need to add the git-email package so we can access the git send-email command.