### PR TITLE
mutt_setup/sent: Fix the name of the Sent folder.

### DIFF
--- a/roles/mutt_setup/files/user-raithlin
+++ b/roles/mutt_setup/files/user-raithlin
@@ -10,7 +10,7 @@ set smtp_oauth_refresh_command=${imap_oauth_refresh_command}
 set folder = "imaps://outlook.office365.com/"
 set spoolfile = "+INBOX"
 set postponed = "+/Drafts"
-set record = "+/Sent"
+set record = "+/Sent Items"
 set trash = "+/Deleted Items"
 # other settings
 set message_cachedir="~/.mutt/cache/raithlin/bodies"


### PR DESCRIPTION
It turns out the correct name for my raithlin sent folder is "Sent Items" and not "Sent". So fix this to avoid a warning when sending mail.