### PR TITLE
qemu_setup/risc-v: Add the qemu-system-misc package

### DIFF
--- a/roles/qemu_setup/tasks/main.yml
+++ b/roles/qemu_setup/tasks/main.yml
@@ -32,6 +32,8 @@
       - libvirt-clients
       - libvirt-daemon-system
       - qemu-kvm
+      - qemu-system-misc
+      - u-boot-emu
       - virt-manager
       - virtinst
   become: true


### PR DESCRIPTION
Add this package so qemu-system works for emulating riscv architectures.