### PR TITLE
mutt_setup/files: Fix the double sent messages

### DIFF
--- a/roles/mutt_setup/files/user-raithlin
+++ b/roles/mutt_setup/files/user-raithlin
@@ -10,6 +10,7 @@ set smtp_oauth_refresh_command=${imap_oauth_refresh_command}
 set folder = "imaps://outlook.office365.com/"
 set spoolfile = "+INBOX"
 set postponed = "+/Drafts"
+set copy = no
 set record = "+/Sent Items"
 set trash = "+/Deleted Items"
 # other settings


### PR DESCRIPTION
Currently two copies of outgoing messages are placed in the sent folder in the Raithlin email. We can fix this using this patch.