### PR TITLE
docker: Add a simple docker-based test platform.

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -1,5 +1,6 @@
 Ansible
 Compatability
+Dockerfile
 DOM
 DOMs
 Gmail

--- a/README.md
+++ b/README.md
@@ -98,6 +98,23 @@ ansible-playbook.
 Some of the more involved roles have their own README.md. Please refer
 to them for more information about a specific role.
 
+## Playbook and Role Testing
+
+This project contains a [docker](./docker) directory that contains a
+Dockerfile and a bash script that allows simple testing of these
+playbooks and roles. This is based on [this tutorial][ref-docker-tut]
+with some of my own modifications.
+
+You can run a test for any of the roles in this repo by calling the
+following from the top-level directory of a given role.
+```
+MAC_MODE=no CLEAN_UP=yes ../../docker/test-playbook tests/test.yml
+```
+This runs the test playbook in the ```tests/test.yml``` file using a
+docker container based on Ubuntu Noble. You can change to
+```MAC_MODE=yes``` when running on Mac OS X and ```CLEAN_UP=no``` if
+you want to leave the container running for debug purposes.
+
 ## Useful Ansible Commands
 
 As this repository has developed we have come across some very useful
@@ -113,3 +130,4 @@ by target machine name.
 
 [1]: https://github.com/sbates130272/qemu-minimal/blob/master/scripts/gen-image
 [ref-ansible-ppa]: https://launchpad.net/~ansible/+archive/ubuntu/ansible
+[ref-docker-tut]: https://dev.to/pencillr/test-ansible-playbooks-using-docker-ci0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,34 @@
+FROM ubuntu:noble
+
+ARG USER=${USER}
+
+# Add sudo and openssh-server
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt update && \
+  apt install -y \
+    python3-debian \
+    openssh-server \
+    sudo
+
+# Setup running user on the container with sudo rights and
+# password-less ssh login
+RUN useradd -m ${USER}
+RUN adduser ${USER} sudo
+RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/sudoers
+
+# As the user setup the ssh identity using the key in the tmp folder
+USER "${USER}"
+RUN mkdir ~/.ssh
+RUN chmod -R 700 ~/.ssh
+COPY --chown=${USER}:sudo id_rsa.pub /home/${USER}/.ssh/id_rsa.pub
+RUN cat ~/.ssh/id_rsa.pub >> ~/.ssh/authorized_keys
+RUN chmod 644 ~/.ssh/id_rsa.pub
+RUN chmod 644 ~/.ssh/authorized_keys
+
+# start ssh with port exposed
+USER root
+RUN service ssh start
+
+EXPOSE 22
+
+CMD ["/usr/sbin/sshd", "-D"]

--- a/docker/test-playbook
+++ b/docker/test-playbook
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+MAC_MODE=${MAC_MODE:-no}
+CLEAN_UP=${CLEAN_UP:-yes}
+
+UUID=$(uuidgen)
+CONTAINER_NAME="test-playbook-${UUID}"
+DOCKER_DIR="$(dirname "$(readlink -f "$0")")"
+
+echo $UUID
+echo $CONTAINER_NAME
+echo $DOCKER_DIR
+echo $PWD
+
+function cleanup() {
+
+    CONTAINER_ID=$(docker inspect --format="{{.Id}}" ${CONTAINER_NAME} ||:)
+    if [ $CLEAN_UP == "yes" ]; then
+	if [[ -n ${CONTAINER_ID} ]]; then
+            echo "Cleaning up container ${CONTAINER_NAME}"
+            docker rm --force ${CONTAINER_ID}
+	fi
+	if [[ -d ${TEMP_DIR} ]]; then
+            echo "Cleaning up temporary directory ${TEMP_DIR}"
+            rm -rf ${TEMP_DIR}
+	fi
+    else
+	echo "Left ${CONTAINER_NAME} running, files in ${TEMP_DIR}."
+    fi
+}
+
+trap cleanup EXIT
+
+TEMP_DIR=$(mktemp --directory /tmp/${CONTAINER_NAME}.XXXXXXXX)
+
+ssh-keygen -b 2048 -t rsa -C ${USER}@email.com -f ${TEMP_DIR}/id_rsa -N ""
+chmod 600 "${TEMP_DIR}/id_rsa"
+chmod 644 "${TEMP_DIR}/id_rsa.pub"
+
+docker build --tag test-playbook \
+       --build-arg USER \
+       --file ${DOCKER_DIR}/Dockerfile \
+       ${TEMP_DIR}
+docker run -d -P --name ${CONTAINER_NAME} test-playbook
+
+if [ $MAC_MODE == "no" ]; then
+    CONTAINER_ADDR=$(docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${CONTAINER_NAME})
+    CONTAINER_PORT=22
+elif [ $MAC_MODE == "yes" ]; then
+    CONTAINER_ADDR=localhost
+    CONTAINER_PORT=$(docker inspect --format='{{ (index .NetworkSettings.Ports "22/tcp" 0).HostPort }}' ${CONTAINER_NAME})
+else
+    echo "ERROR: MAC_MODE must be yes or no (${MAC_MODE})."
+    exit 1
+fi
+
+cat > ${TEMP_DIR}/hosts << EOL
+[target_group]
+${CONTAINER_ADDR}:${CONTAINER_PORT}
+[target_group:vars]
+ansible_ssh_private_key_file=${TEMP_DIR}/id_rsa
+EOL
+
+cat > ${TEMP_DIR}/ansible.cfg << EOL
+[defaults]
+# Avoid host key checking - to to run without interaction.
+host_key_checking = False
+# Add the project roles path so we can find our roles
+roles_path = $(PWD)/../
+EOL
+
+ANSIBLE_CONFIG=${TEMP_DIR}/ansible.cfg
+export ANSIBLE_CONFIG
+ansible-playbook -i ${TEMP_DIR}/hosts $1


### PR DESCRIPTION
Add a simple Docker container based testing framework we can use for quick and easy local testing without tainting our local machine. We use temporary Docker containers to run test playbooks and roles. Based on this tutorial [1].

[1]: https://dev.to/pencillr/test-ansible-playbooks-using-docker-ci0