### PR TITLE
groups[]: Fix error when group is missing

### DIFF
--- a/roles/fio_devel/tasks/main.yml
+++ b/roles/fio_devel/tasks/main.yml
@@ -36,7 +36,7 @@
   ansible.builtin.setup:
     gather_subset:
       - kernel
-  when: inventory_hostname in groups['awsmachines']
+  when: inventory_hostname in groups['awsmachines'] | default([])
 
 - name: Install fio related packages when on AWS
   ansible.builtin.package:
@@ -44,7 +44,7 @@
       - linux-tools-{{ ansible_kernel }}
       - linux-tools-aws
   become: true
-  when: inventory_hostname in groups['awsmachines']
+  when: inventory_hostname in groups['awsmachines'] | default([])
 
 - name: Ensure Projects folder exists.
   ansible.builtin.file:

--- a/roles/git_setup/tasks/main.yml
+++ b/roles/git_setup/tasks/main.yml
@@ -28,8 +28,8 @@
       - --exclude=*~
       - --exclude=*.conf
   when:
-    - inventory_hostname not in groups['locals'] and
-      inventory_hostname not in groups['runners']
+    - inventory_hostname not in groups['locals'] | default([]) and
+      inventory_hostname not in groups['runners'] | default([])
 
 - name: Setup emacs as git editor
   community.general.git_config:


### PR DESCRIPTION
Fix an issue that can occur when a given group key is missing. Do so by adding a default which kicks in when the group key does not exist.