### PR TITLE
ubuntu-ci: Alter the Ubuntu versions to do CI on

### DIFF
--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -10,7 +10,7 @@ jobs:
   build-spellcheck-lint-test:
     strategy:
       matrix:
-        runs-on: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04]
+        runs-on: [ubuntu-22.04, ubuntu-24.04]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code


### PR DESCRIPTION
GitHub has been depreciating its Ubuntu-20.04 runner and so we remove that and add the 25.04 release.