### PR TITLE
roles/rocm_setup: Add rocm_setup role

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -12,7 +12,9 @@ MacOS
 NVMe
 OAuth
 Pre
+Radeon
 README
+ROCm
 SSDs
 VM
 VMs
@@ -34,6 +36,7 @@ ppa
 qemu
 raithlin
 repo
+rocm
 rsa
 sbates
 sudo

--- a/roles/rocm_setup/README.md
+++ b/roles/rocm_setup/README.md
@@ -1,0 +1,41 @@
+# AMD ROCm Setup
+
+An Ansible role to install and setup a complete [AMD ROCm][ref-rocm]
+environment compatible with AMD [Radeon][ref-radeon] and
+[Instinct][ref-instinct] accelerators.
+
+## Overview
+
+This role installs ROCm using [these instructions][ref-install] as a guide.
+
+## Requirements
+
+# Role Variables
+
+See the [defaults file](./defaults/main.yml) for more information on
+the variables associated with this file. Note there is also a
+[rocm-latest](./files/rocm-latest) script that can be used to detect
+the latest version of the `rocm` and `amdgpu` packages.
+
+# Dependencies
+
+# Example Playbook
+
+# Testing
+
+Run the following from the folder this README resides in.
+```
+ANSIBLE_ROLES_PATH=../ ansible-playbook -i <host_file> ./tests/test.yml
+```
+There is an [example hosts file](./tests/hosts-example) that users can
+use as a template for their testing.
+
+# Author and License Information
+
+See the [meta file](./meta/main.yml) for more information on the
+author, licensing and other details.
+
+[ref-rocm]: https://www.amd.com/en/products/software/rocm.html
+[ref-radeon]: https://www.amd.com/en/products/graphics/desktops/radeon.html
+[ref-instinct]: https://www.amd.com/en/products/accelerators/instinct.html
+[ref-install]: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/index.html

--- a/roles/rocm_setup/defaults/main.yml
+++ b/roles/rocm_setup/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# defaults file for rocm-setup
+
+# The version of ROCm to install. See
+# https://rocm.docs.amd.com/en/latest/ for the actual latest
+# version and for older versions.
+rocm_setup_version: 7.0.1
+rocm_setup_amdgpu_version: 30.10.1
+
+# The user to set ROCm up for. This includes adding to the revelant
+# user groups etc.
+rocm_setup_user: rocm_user
+
+# The reboot time to wait for. Note we can set this a lot less for a
+# VM than for a bare-metal
+rocm_setup_reboot: 300

--- a/roles/rocm_setup/files/hip-hello-world.cpp
+++ b/roles/rocm_setup/files/hip-hello-world.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <hip/hip_runtime.h>
+
+// This is a HIP kernel that prints to standard output
+__global__ void hello_world_kernel() {
+    printf("Hello, World from GPU!\n");
+}
+
+int main() {
+    // Launch the kernel on the device (GPU)
+    // This syntax launches the kernel with a grid of 1 block and 1 thread per block
+    hello_world_kernel<<<1, 1>>>();
+
+    // Synchronize to make sure the kernel has finished executing before exiting
+    hipDeviceSynchronize();
+
+    // Print a confirmation from the host (CPU)
+    std::cout << "Kernel execution finished." << std::endl;
+
+    return 0;
+}

--- a/roles/rocm_setup/files/rocm-latest
+++ b/roles/rocm_setup/files/rocm-latest
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# A simple bash script that uses curl to obtain the latest release of
+# ROCm and amdgpu packages via our packaging repo. Use QUIET=true to
+# only display the version tag. Use ONLY_ONE=[ROCM|AMDGPU] to only
+# output the version tag for either ROCm or amdgpu.
+
+RADEON_REPO=${RADEON_REPO:-https://repo.radeon.com}
+QUIET=${QUIET:-false}
+ONLY_ONE=${ONLY_ONE:-false}
+
+ROCM_REMOTE=${RADEON_REPO}/rocm/apt/
+AMDGPU_REMOTE=${RADEON_REPO}/amdgpu/
+
+parse_repo () {
+    VERSION=$(curl -s ${1} | \
+      sed -nE 's/^<a href="([0-9.]+*)\/">*.*/\1/p' | \
+      sort -g | tail -n 1)
+    echo $VERSION
+}
+
+if [ ${ONLY_ONE} != "AMDGPU" ]; then
+
+    ROCM_VERSION=$(parse_repo $ROCM_REMOTE)
+    if [ ${QUIET} == "true" ]; then
+        echo ${ROCM_VERSION}
+    else
+        echo "ROCm latest: ${ROCM_VERSION}."
+    fi
+fi
+
+if [ ${ONLY_ONE} != "ROCM" ]; then
+    AMDGPU_VERSION=$(parse_repo $AMDGPU_REMOTE)
+    if [ ${QUIET} == "true" ]; then
+        echo ${AMDGPU_VERSION}
+    else
+        echo "AMDGPU latest: ${AMDGPU_VERSION}."
+    fi
+fi

--- a/roles/rocm_setup/files/rocm-pin-600
+++ b/roles/rocm_setup/files/rocm-pin-600
@@ -1,0 +1,3 @@
+Package: *
+Pin: release o=repo.radeon.com
+Pin-Priority: 600

--- a/roles/rocm_setup/meta/main.yml
+++ b/roles/rocm_setup/meta/main.yml
@@ -1,0 +1,20 @@
+---
+# meta file for rocm-setup
+
+galaxy_info:
+  author: Stephen Bates
+  company: Raithlin Semiconductors
+  role_name: rocm_setup
+  namespace: sbates130272
+  description: A role to install the AMD ROCm software framework
+  license: BSD-3-Clause
+  min_ansible_version: "8.2.0"
+  platforms:
+    - name: Ubuntu
+      versions:
+        - noble
+  galaxy_tags:
+    - system
+    - amd
+    - rocm
+    - gpu

--- a/roles/rocm_setup/tasks/main.yml
+++ b/roles/rocm_setup/tasks/main.yml
@@ -1,0 +1,89 @@
+---
+# Copyright (c) Stephen Bates, 2022
+#
+# AMD ROCm software install and setup.
+
+- name: Set a fact containing the current roles' path
+  ansible.builtin.set_fact:
+    calling_role_path_fact: "{{ role_path }}"
+
+- name: Test the host platform to see if it can support this role
+  ansible.builtin.include_role:
+    name: check_platform
+  vars:
+    calling_role_path: "{{ calling_role_path_fact }}"
+
+- name: Run the rocm_setup prerequisite steps
+  ansible.builtin.import_tasks:
+    file: rocm_pre.yml
+
+- name: Add the AMD ROCm apt siging key and repo
+  ansible.builtin.deb822_repository:
+    name: rocm
+    types: deb
+    uris:
+      - https://repo.radeon.com/rocm/apt/{{ rocm_setup_version }}
+      - https://repo.radeon.com/graphics/{{ rocm_setup_version }}/ubuntu
+      - https://repo.radeon.com/amdgpu/{{ rocm_setup_amdgpu_version }}/ubuntu
+    suites: '{{ ansible_distribution_release }}'
+    components: main
+    architectures: amd64
+    signed_by: https://repo.radeon.com/rocm/rocm.gpg.key
+  become: true
+
+- name: Create a rocm-pin-600 file to pin the repos want to install
+  ansible.builtin.copy:
+    content: |
+      Package: *
+      Pin: release o=repo.radeon.com
+      Pin-Priority: 600
+    dest: /etc/apt/preferences.d/rocm-pin-600
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+- name: Install the rocm meta-package
+  ansible.builtin.package:
+    update_cache: true
+    name:
+      - libstdc++-14-dev
+      - rocm
+  become: true
+
+- name: Update the library linker with rocm library paths
+  ansible.builtin.copy:
+    content: |
+      /opt/rocm/lib
+      /opt/rocm/lib64
+    dest: /etc/ld.so.conf.d/rocm.conf
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+- name: Run ldconfig to ensure library updates take effect
+  ansible.builtin.shell:
+    cmd: ldconfig
+  become: true
+
+- name: Update the PCIe ID tables (for new GPU support)
+  ansible.builtin.shell:
+    cmd: update-pciids
+  become: true
+
+- name: Install the amdgpu-dkms package
+  ansible.builtin.package:
+    update_cache: true
+    name:
+      - amdgpu-dkms
+  become: true
+
+- name: Perform a reboot to allow changes to take affect
+  ansible.builtin.reboot:
+    reboot_timeout: "{{ rocm_setup_reboot }}"
+  become: true
+
+- name: Run the rocm checks to ensure install worked
+  ansible.builtin.import_tasks:
+    file: rocm_check.yml

--- a/roles/rocm_setup/tasks/rocm_check.yml
+++ b/roles/rocm_setup/tasks/rocm_check.yml
@@ -1,0 +1,17 @@
+- name: Check that rocminfo works
+  ansible.builtin.shell:
+    cmd: rocminfo
+
+- name: Copy test HIP program to target
+  ansible.builtin.copy:
+    src: ./files/hip-hello-world.cpp
+    dest: /tmp/
+    owner: "{{ rocm_setup_user }}"
+    group: "{{ rocm_setup_user }}"
+    mode: '0644'
+  become: true
+
+
+- name: Check that we can compile a very simple program
+  ansible.builtin.shell:
+    cmd: hipcc -o /tmp/hip-hello-world /tmp/hip-hello-world.cpp

--- a/roles/rocm_setup/tasks/rocm_pre.yml
+++ b/roles/rocm_setup/tasks/rocm_pre.yml
@@ -1,0 +1,88 @@
+- name: Copy the rocm-latest script to the host
+  ansible.builtin.copy:
+    src: rocm-latest
+    dest: /usr/local/bin/rocm-latest
+    owner: root
+    group: root
+    mode: '0755'
+  become: true
+
+- name: Run the rocm-latest script and register results
+  ansible.builtin.shell:
+    cmd: rocm-latest
+  environment:
+    QUIET: "true"
+    ONLY_ONE: ROCM
+  register: rocm_version
+
+- name: Run the rocm-latest script and register results
+  ansible.builtin.shell:
+    cmd: rocm-latest
+  environment:
+    QUIET: "true"
+    ONLY_ONE: AMDGPU
+  register: amdgpu_version
+
+- name: Print the rocm package version
+  ansible.builtin.debug:
+    msg: "rocm version: {{ rocm_version.stdout }}"
+
+- name: Print the amdgpu package version
+  ansible.builtin.debug:
+    msg: "amdgpu version: {{ amdgpu_version.stdout }}"
+
+- name: Fail if rocm_version does not match rocm_setup_version
+  ansible.builtin.fail:
+    msg: "You are not requesting the latest rocm version!"
+  when: rocm_version.stdout != rocm_setup_version
+
+- name: Fail if amdgpu_version does not match rocm_setup_amdgpu_version
+  ansible.builtin.fail:
+    msg: "You are not requesting the latest amdgpu version!"
+  when: amdgpu_version.stdout != rocm_setup_amdgpu_version
+
+- name: Perform an update, upgrade and autoremove
+  ansible.builtin.apt:
+    update_cache: true
+    upgrade: full
+    autoremove: true
+  become: true
+
+- name: Perform a reboot to allow kernel updates
+  ansible.builtin.reboot:
+    reboot_timeout: "{{ rocm_setup_reboot }}"
+  become: true
+
+- name: Update ansible_kernel as it may have changed
+  ansible.builtin.setup:
+    filter:
+      - ansible_kernel
+
+- name: Install the prerequisite packages needed for ROCm install
+  ansible.builtin.package:
+    update_cache: true
+    name:
+      - linux-headers-{{ ansible_kernel }}
+      - linux-modules-extra-{{ ansible_kernel }}
+      - python3-setuptools
+      - python3-wheel
+  become: true
+
+- name: Ensure the video and render groups exist
+  ansible.builtin.group:
+    name: "{{ item }}"
+    state: present
+  loop:
+    - video
+    - render
+  become: true
+
+- name: Ensure the requested user is a member of above groups
+  ansible.builtin.user:
+    name: "{{ rocm_setup_user }}"
+    groups: "{{ item }}"
+    append: true
+  loop:
+    - video
+    - render
+  become: true

--- a/roles/rocm_setup/tests/hosts-example
+++ b/roles/rocm_setup/tests/hosts-example
@@ -1,0 +1,8 @@
+rocm_servers:
+  hosts:
+    snoc-think-vm:
+        rocm_setup_user: stebates
+        rocm_setup_reboot: 30
+        ansible_host: snoc-think
+        ansible_port: 2222
+        ansible_user: stebates

--- a/roles/rocm_setup/tests/test.yml
+++ b/roles/rocm_setup/tests/test.yml
@@ -1,0 +1,6 @@
+---
+- name: The test playbook for the rocm_setup role
+  hosts: all
+  roles:
+    - role: rocm_setup
+      become: false


### PR DESCRIPTION
This commit adds a new role which sets up the AMD ROCm stack on Ubuntu 24.04 machines. It uses the instructions provided in the AMD ROCm documentation. It also installs the amdgpu-dkms code to obtain the latest kernel driver code for the GPUs.

It then performs some simple tests to ensure at least basic functionality.