### PR TITLE
rocm_setup: Change the reboot conditional

### DIFF
--- a/roles/rocm_setup/tasks/main.yml
+++ b/roles/rocm_setup/tasks/main.yml
@@ -83,7 +83,7 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ rocm_setup_reboot }}"
   become: true
-  when: inventory_hostname not in groups['runners'] | default([])
+  when: ansible_connection != 'local'
 
 - name: Run the rocm checks to ensure install worked
   ansible.builtin.import_tasks:

--- a/roles/rocm_setup/tasks/rocm_pre.yml
+++ b/roles/rocm_setup/tasks/rocm_pre.yml
@@ -52,7 +52,7 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ rocm_setup_reboot_timeout }}"
   become: true
-  when: inventory_hostname not in groups['runners'] | default([])
+  when: ansible_connection != 'local'
 
 - name: Update ansible_kernel as it may have changed
   ansible.builtin.setup:


### PR DESCRIPTION
We can simply avoid reboot when ansible_connection is local. This should cover all cases and is more robust than using inventory groups.