### PR TITLE
amd-setup.yml: Add the rocm_setup role to the playbook.

### DIFF
--- a/playbooks/setup-amd.yml
+++ b/playbooks/setup-amd.yml
@@ -18,3 +18,7 @@
       remote_user: "{{ username }}"
       become: false
       tags: [git_setup]
+    - role: rocm_setup
+      remote_user: "{{ username }}"
+      become: false
+      tags: [rocm_setup]


### PR DESCRIPTION
Now we have a rocm_setup role we add that to the AMD-specific playbook.