### PR TITLE
user_setup/emacs: Update our emacs related files and tasks

### DIFF
--- a/roles/user_setup/files/.emacs
+++ b/roles/user_setup/files/.emacs
@@ -12,3 +12,7 @@
 (setq-default show-trailing-whitespace t)
 ;; default to auto-fill-mode on in all major modes
 (setq-default auto-fill-function 'do-auto-fill)
+;; add a rust mode
+(require 'rust-mode)
+;; treat .hip files as .cpp
+(add-to-list 'auto-mode-alist '("\\.hip\\'" . c++-mode))

--- a/roles/user_setup/files/init.el
+++ b/roles/user_setup/files/init.el
@@ -1,0 +1,5 @@
+(require 'package)
+(setq package-archives '(("gnu" . "https://elpa.gnu.org/packages/")
+                         ("melpa" . "https://melpa.org/packages/")))
+(package-initialize)
+(package-refresh-contents)

--- a/roles/user_setup/tasks/main.yml
+++ b/roles/user_setup/tasks/main.yml
@@ -128,6 +128,23 @@
     - ServerAliveCountMax 30
     - StrictHostKeyChecking accept-new
 
+- name: Ensure .emacs.d folder exists
+  ansible.builtin.file:
+    path: /home/{{ username }}/.emacs.d
+    state: directory
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0644"
+
+- name: Copy emacs config file from our files folder
+  ansible.builtin.copy:
+    force: true
+    src: init.el
+    dest: /home/{{ username }}/.emacs.d/init.el
+    owner: "{{ username }}"
+    group: "{{ username }}"
+    mode: "0644"
+
 - name: Copy emacs config file from our files folder
   ansible.builtin.copy:
     force: true


### PR DESCRIPTION
In order to load in rust-mode we add an init.el file to the .emacs.d folder. We then upload a new .emacs. We also set .emacs to open .hip files with c++-mode.