### PR TITLE
rocm_setup: Add ability to default to latest version

### DIFF
--- a/roles/rocm_setup/README.md
+++ b/roles/rocm_setup/README.md
@@ -17,6 +17,12 @@ the variables associated with this file. Note there is also a
 [rocm-latest](./files/rocm-latest) script that can be used to detect
 the latest version of the `rocm` and `amdgpu` packages.
 
+Note that `rocm_setup_version` and `rocm_setup_amdgpu_version` can be
+set to `latest`. In this case the [rocm-latest](./files/rocm-latest)
+script will be used to set the versions to install. If you do want to
+install an older version then set the version variables and also set
+`rocm_setup_force_version` to `true`.
+
 # Dependencies
 
 # Example Playbook

--- a/roles/rocm_setup/defaults/main.yml
+++ b/roles/rocm_setup/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
 # defaults file for rocm-setup
 
-# The version of ROCm to install. See
-# https://rocm.docs.amd.com/en/latest/ for the actual latest
-# version and for older versions.
-rocm_setup_version: 7.0.1
-rocm_setup_amdgpu_version: 30.10.1
+# The version of ROCm to install. Set to latest to use rocm-latest
+# script to detect lastest.
+rocm_setup_rocm_version: latest
+rocm_setup_amdgpu_version: latest
+rocm_setup_force_version: false
 
 # The user to set ROCm up for. This includes adding to the revelant
 # user groups etc.

--- a/roles/rocm_setup/tasks/main.yml
+++ b/roles/rocm_setup/tasks/main.yml
@@ -22,8 +22,8 @@
     name: rocm
     types: deb
     uris:
-      - https://repo.radeon.com/rocm/apt/{{ rocm_setup_version }}
-      - https://repo.radeon.com/graphics/{{ rocm_setup_version }}/ubuntu
+      - https://repo.radeon.com/rocm/apt/{{ rocm_setup_rocm_version }}
+      - https://repo.radeon.com/graphics/{{ rocm_setup_rocm_version }}/ubuntu
       - https://repo.radeon.com/amdgpu/{{ rocm_setup_amdgpu_version }}/ubuntu
     suites: '{{ ansible_distribution_release }}'
     components: main
@@ -81,7 +81,7 @@
 
 - name: Perform a reboot to allow changes to take affect
   ansible.builtin.reboot:
-    reboot_timeout: "{{ rocm_setup_reboot }}"
+    reboot_timeout: "{{ rocm_setup_reboot_timeout }}"
   become: true
   when: ansible_connection != 'local'
 

--- a/roles/rocm_setup/tasks/rocm_pre.yml
+++ b/roles/rocm_setup/tasks/rocm_pre.yml
@@ -13,7 +13,7 @@
   environment:
     QUIET: "true"
     ONLY_ONE: ROCM
-  register: rocm_version
+  register: rocm_latest_version
 
 - name: Run the rocm-latest script and register results
   ansible.builtin.shell:
@@ -21,25 +21,35 @@
   environment:
     QUIET: "true"
     ONLY_ONE: AMDGPU
-  register: amdgpu_version
+  register: amdgpu_latest_version
 
 - name: Print the rocm package version
   ansible.builtin.debug:
-    msg: "rocm version: {{ rocm_version.stdout }}"
+    msg: "rocm latest_version: {{ rocm_latest_version.stdout }}"
 
 - name: Print the amdgpu package version
   ansible.builtin.debug:
-    msg: "amdgpu version: {{ amdgpu_version.stdout }}"
+    msg: "amdgpu latest version: {{ amdgpu_latest_version.stdout }}"
 
-- name: Fail if rocm_version does not match rocm_setup_version
+- name: Populate rocm_setup_rocm_version variable
+  ansible.builtin.set_fact:
+    rocm_setup_rocm_version: "{{ rocm_latest_version.stdout }}"
+  when: rocm_setup_rocm_version == 'latest'
+
+- name: Populate rocm_setup_amdgpu_version variable
+  ansible.builtin.set_fact:
+    rocm_setup_amdgpu_version: "{{ amdgpu_latest_version.stdout }}"
+  when: rocm_setup_amdgpu_version == 'latest'
+
+- name: Fail if rocm_latest_version does not match rocm_setup_version (unless forced)
   ansible.builtin.fail:
     msg: "You are not requesting the latest rocm version!"
-  when: rocm_version.stdout != rocm_setup_version
+  when: rocm_latest_version.stdout != rocm_setup_rocm_version and not rocm_setup_version_force
 
-- name: Fail if amdgpu_version does not match rocm_setup_amdgpu_version
+- name: Fail if amdgpu_latest_version does not match rocm_setup_amdgpu_version (unless forced)
   ansible.builtin.fail:
     msg: "You are not requesting the latest amdgpu version!"
-  when: amdgpu_version.stdout != rocm_setup_amdgpu_version
+  when: amdgpu_latest_version.stdout != rocm_setup_amdgpu_version and not rocm_setup_version_force
 
 - name: Perform an update, upgrade and autoremove
   ansible.builtin.apt:


### PR DESCRIPTION
Add a 'latest' value to the rocm_setup_*_version variables that sets the versions to what is detected by rocm-latest script. Make these the default values. Also add a force variable to allow users to install a non-latest version.