### PR TITLE
feat: Add optional GitHub OAuth SSO authentication to grafana_setup

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -35,6 +35,7 @@ WSL
 amd
 amdgpu
 ansible
+auth
 aws
 batesste
 cd
@@ -46,11 +47,14 @@ emacs
 exporter
 filesystem
 fstab
+github
 gmail
 grafana
 gnupgp
 homelab
 hostname
+http
+https
 libvirt
 localhost
 localmachines
@@ -59,6 +63,7 @@ md
 mlx
 motd
 myuser
+orgs
 passthru
 passwordless
 pci
@@ -78,6 +83,7 @@ systemd
 tmp
 txt
 ubuntu
+url
 usr
 vCPUs
 vfio

--- a/roles/grafana_setup/defaults/main.yml
+++ b/roles/grafana_setup/defaults/main.yml
@@ -6,6 +6,18 @@ grafana_setup_user: "{{ ansible_user }}"
 grafana_setup_password: "{{ vault_grafana_setup_password }}"
 grafana_setup_port: 3000
 grafana_setup_domain: localhost
+grafana_setup_root_url: >-
+  http://{{ grafana_setup_domain }}:{{ grafana_setup_port }}/
+
+# GitHub OAuth configuration (optional)
+grafana_setup_github_auth_enabled: false
+grafana_setup_github_client_id: >-
+  {{ vault_grafana_setup_github_client_id | default('') }}
+grafana_setup_github_client_secret: >-
+  {{ vault_grafana_setup_github_client_secret | default('') }}
+grafana_setup_github_allowed_orgs: []
+grafana_setup_github_allow_sign_up: true
+grafana_setup_github_auto_assign_org_role: Editor
 
 # Prometheus configuration
 grafana_setup_prometheus_port: 9090

--- a/roles/grafana_setup/templates/grafana.ini.j2
+++ b/roles/grafana_setup/templates/grafana.ini.j2
@@ -11,7 +11,7 @@ provisioning = /etc/grafana/provisioning
 protocol = http
 http_port = {{ grafana_setup_port }}
 domain = {{ grafana_setup_domain }}
-root_url = http://{{ grafana_setup_domain }}:{{ grafana_setup_port }}/
+root_url = {{ grafana_setup_root_url }}
 
 [database]
 type = sqlite3
@@ -41,6 +41,23 @@ enabled = false
 [auth.basic]
 enabled = true
 
+{% if grafana_setup_github_auth_enabled %}
+[auth.github]
+enabled = true
+allow_sign_up = {{ grafana_setup_github_allow_sign_up | lower }}
+client_id = {{ grafana_setup_github_client_id }}
+client_secret = {{ grafana_setup_github_client_secret }}
+scopes = user:email,read:org
+auth_url = https://github.com/login/oauth/authorize
+token_url = https://github.com/login/oauth/access_token
+api_url = https://api.github.com/user
+{% if grafana_setup_github_allowed_orgs | length > 0 %}
+allowed_organizations = {{ grafana_setup_github_allowed_orgs | join(',') }}
+{% endif %}
+auto_assign_org = true
+auto_assign_org_role = {{ grafana_setup_github_auto_assign_org_role }}
+
+{% endif %}
 [auth]
 # Disable login form
 disable_login_form = false


### PR DESCRIPTION
Add GitHub OAuth integration as an optional authentication method for Grafana while maintaining password authentication as the default.

New Features:
- GitHub OAuth SSO authentication (disabled by default)
- Organization-based access control
- Configurable auto-assignment of user roles
- Secure vault variable integration for OAuth credentials

Configuration Variables:
- grafana_setup_github_auth_enabled: Enable/disable GitHub OAuth
- grafana_setup_github_client_id: OAuth client ID (from vault)
- grafana_setup_github_client_secret: OAuth client secret (from vault)
- grafana_setup_github_allowed_orgs: Restrict to specific GitHub orgs
- grafana_setup_github_allow_sign_up: Allow new user registration
- grafana_setup_github_auto_assign_org_role: Default role for new users
- grafana_setup_root_url: Configurable root URL for OAuth callbacks

Documentation:
- Complete GitHub OAuth setup guide in README
- Step-by-step instructions for creating GitHub OAuth app
- Example playbooks for both auth methods
- Vault variable documentation

Technical:
- All variables properly prefixed with 'grafana_setup_'
- 80-column compliance using YAML folded scalars
- Backward compatible - password auth remains default
- Conditional Jinja2 templating in grafana.ini