### PR TITLE
Update grafana_setup to use AMD Instinct dashboard for Device Metrics…

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -15,10 +15,14 @@ GPUs
 HTTPS
 Homebrew
 InfiniBand
+Instinct
 IPv
 JSON
 LTS
 MacOS
+MI100
+MI200
+MI300
 MKMSTEBATES
 MOTD
 Mellanox

--- a/roles/grafana_setup/NETWORK_DISCOVERY.md
+++ b/roles/grafana_setup/NETWORK_DISCOVERY.md
@@ -30,28 +30,28 @@ grafana_setup_discovery_scan_timeout: 60  # Max scan time in seconds
 - Maximum retry count of 1 to reduce scan time
 - Overall scan limited to 60 seconds (default, configurable)
 
-### 2. AMD SMI Exporter Discovery
+### 2. AMD Device Metrics Exporter Discovery
 
-Automatically finds AMD SMI exporters on your network ([official AMD exporter](https://github.com/amd/amd_smi_exporter)):
+Automatically finds AMD Device Metrics exporters on your network ([official ROCm exporter](https://github.com/ROCm/device-metrics-exporter)):
 
 ```yaml
 grafana_setup_discover_amd_gpu_exporters: true
-grafana_setup_amd_gpu_exporter_port: 2021  # AMD SMI Exporter default port
+grafana_setup_amd_gpu_exporter_port: 2021  # AMD Device Metrics Exporter default port
 grafana_setup_discovery_scan_timeout: 60  # Max scan time in seconds
 ```
 
 **How it works:**
-1. Uses optimized `nmap` to scan for the AMD SMI Exporter port (default: 2021)
+1. Uses optimized `nmap` to scan for the AMD Device Metrics Exporter port (default: 2021)
 2. Scan is limited to maximum of 60 seconds (same timeout as node exporters)
-3. Verifies each host is responding with AMD EPYC CPU & GPU metrics
+3. Verifies each host is responding with AMD GPU metrics
 4. Creates a dedicated `amd_gpu` job in Prometheus
 5. Labels targets with `group: 'gpus'` and `discovered: 'true'`
 
-**What is AMD SMI Exporter?**
-- Official AMD exporter for EPYC CPUs and Datacenter GPUs (MI200, MI300)
-- Exports CPU metrics (core energy, socket power, boost limits, PROC_HOT status)
+**What is AMD Device Metrics Exporter?**
+- Official AMD ROCm exporter for Datacenter GPUs (MI100, MI200, MI300 series)
 - Exports GPU metrics (power, temperature, clock speeds, utilization, memory)
-- Written in Go with AMD SMI library bindings
+- Integrates seamlessly with Prometheus and Grafana
+- Part of the official ROCm software stack
 
 **Performance:**
 - Same optimizations as Node Exporter discovery
@@ -69,10 +69,11 @@ Automatically downloads and provisions dashboards:
 - Metrics: CPU, memory, disk, network for all nodes
 
 **AMD GPU Dashboard:**
-- Dashboard ID: 12239
-- Name: AMD GPU Metrics
+- Dashboard ID: 23434
+- Name: AMD Instinct Single Node Dashboard
 - URL: http://localhost:3000/d/amd-gpu-metrics
 - Metrics: GPU utilization, temperature, memory, power
+- Designed for AMD Device Metrics Exporter
 
 ## Configuration Example
 
@@ -93,7 +94,7 @@ Automatically downloads and provisions dashboards:
         
         # Custom ports (if needed)
         grafana_setup_node_exporter_port: 9100
-        grafana_setup_amd_gpu_exporter_port: 2021  # AMD SMI Exporter default
+        grafana_setup_amd_gpu_exporter_port: 2021  # AMD Device Metrics Exporter default
         
         # Dashboard provisioning (enabled by default)
         grafana_setup_provision_node_exporter_dashboard: true
@@ -152,7 +153,7 @@ scrape_configs:
           group: 'nodes'
           discovered: 'true'
   
-  # AMD SMI Exporters
+  # AMD Device Metrics Exporters
   - job_name: 'amd_gpu'
     static_configs:
       - targets: ['192.168.1.20:2021']

--- a/roles/grafana_setup/README.md
+++ b/roles/grafana_setup/README.md
@@ -13,7 +13,7 @@ This Ansible role installs and configures Grafana, Prometheus, and Node Exporter
 - Automatically synchronizes admin password on every run
 - Optional creation of additional users with custom roles
 - Automatically configures Prometheus as a datasource in Grafana
-- Network discovery for Node Exporters and AMD SMI exporters
+- Network discovery for Node Exporters and AMD Device Metrics exporters
 - Automatic dashboard provisioning (Node Exporter and AMD GPU)
 - Disables default admin password requirement
 - Configures Prometheus to scrape local Node Exporter
@@ -56,7 +56,8 @@ grafana_setup_prometheus_data_dir: /var/lib/prometheus
 # Node exporter configuration
 grafana_setup_node_exporter_port: 9100
 
-# AMD SMI exporter configuration (https://github.com/amd/amd_smi_exporter)
+# AMD Device Metrics Exporter configuration
+# https://github.com/ROCm/device-metrics-exporter
 grafana_setup_amd_gpu_exporter_port: 2021
 
 # Network discovery configuration
@@ -70,7 +71,7 @@ grafana_setup_discovery_scan_timeout: 60  # Maximum nmap scan time
 grafana_setup_provision_node_exporter_dashboard: true
 grafana_setup_node_exporter_dashboard_id: 1860
 grafana_setup_provision_amd_gpu_dashboard: true
-grafana_setup_amd_gpu_dashboard_id: 12239
+grafana_setup_amd_gpu_dashboard_id: 23434  # AMD Instinct Single Node Dashboard
 
 # Enable/disable components
 grafana_setup_install_prometheus: true
@@ -267,9 +268,9 @@ The role will:
 - Add discovered exporters to Prometheus scrape configuration
 - Label them with `discovered: 'true'` for easy filtering
 
-### AMD SMI Exporter Discovery
+### AMD Device Metrics Exporter Discovery
 
-Enable automatic discovery of AMD SMI exporters ([official AMD exporter](https://github.com/amd/amd_smi_exporter)):
+Enable automatic discovery of AMD Device Metrics exporters ([official ROCm exporter](https://github.com/ROCm/device-metrics-exporter)):
 
 ```yaml
 grafana_setup_discover_amd_gpu_exporters: true
@@ -277,12 +278,12 @@ grafana_setup_amd_gpu_exporter_port: 2021
 ```
 
 The role will:
-- Scan the network for hosts with port 2021 open (AMD SMI Exporter default)
-- Verify each host is responding with AMD EPYC CPU & GPU metrics
-- Add discovered AMD SMI exporters to Prometheus scrape configuration
+- Scan the network for hosts with port 2021 open (AMD Device Metrics Exporter default)
+- Verify each host is responding with AMD GPU metrics
+- Add discovered AMD Device Metrics exporters to Prometheus scrape configuration
 - Create a separate `amd_gpu` job in Prometheus
 
-**Note:** The AMD SMI Exporter supports AMD EPYC CPUs and MI200/MI300 GPUs
+**Note:** The AMD Device Metrics Exporter supports AMD MI100/MI200/MI300 series GPUs
 
 ### Requirements for Discovery
 
@@ -302,9 +303,10 @@ The role automatically provisions dashboards from Grafana.com:
 
 ### AMD GPU Dashboard
 
-- **Dashboard ID**: 12239 (AMD GPU Metrics)
+- **Dashboard ID**: 23434 (AMD Instinct Single Node Dashboard)
 - **URL**: http://localhost:3000/d/amd-gpu-metrics
 - Shows: GPU utilization, temperature, memory, power consumption
+- Designed for AMD Device Metrics Exporter metrics
 
 Both dashboards are automatically configured to use the Prometheus datasource
 and are ready to use immediately after role execution.

--- a/roles/grafana_setup/defaults/main.yml
+++ b/roles/grafana_setup/defaults/main.yml
@@ -36,12 +36,13 @@ grafana_setup_prometheus_data_dir: /var/lib/prometheus
 # Node exporter configuration
 grafana_setup_node_exporter_port: 9100
 
-# AMD SMI exporter configuration (https://github.com/amd/amd_smi_exporter)
+# AMD Device Metrics Exporter configuration
+# https://github.com/ROCm/device-metrics-exporter
 grafana_setup_amd_gpu_exporter_port: 2021
 
 # Network discovery configuration
 grafana_setup_discover_node_exporters: false
-grafana_setup_discover_amd_gpu_exporters: false  # Discovers AMD SMI Exporters
+grafana_setup_discover_amd_gpu_exporters: false  # Discovers AMD Device Metrics Exporters
 grafana_setup_discovery_network: "{{ ansible_default_ipv4.network }}/{{ ansible_default_ipv4.netmask }}"
 grafana_setup_discovery_timeout: 2
 grafana_setup_discovery_scan_timeout: 60  # Maximum scan time in seconds
@@ -51,9 +52,10 @@ grafana_setup_discovery_scan_timeout: 60  # Maximum scan time in seconds
 grafana_setup_provision_node_exporter_dashboard: true
 grafana_setup_node_exporter_dashboard_id: 1860
 
-# AMD GPU / ROCm dashboard - https://grafana.com/grafana/dashboards/12239
+# AMD Instinct Single Node Dashboard - https://grafana.com/grafana/dashboards/23434
+# Designed for AMD Device Metrics Exporter (https://github.com/ROCm/device-metrics-exporter)
 grafana_setup_provision_amd_gpu_dashboard: true
-grafana_setup_amd_gpu_dashboard_id: 12239
+grafana_setup_amd_gpu_dashboard_id: 23434
 
 # Enable/disable components
 grafana_setup_install_prometheus: true

--- a/roles/grafana_setup/tasks/main.yml
+++ b/roles/grafana_setup/tasks/main.yml
@@ -517,7 +517,7 @@
     - grafana_verified_exporter_targets is defined
     - grafana_verified_exporter_targets | length > 0
 
-- name: Scan local network for AMD SMI exporters
+- name: Scan local network for AMD Device Metrics exporters
   ansible.builtin.shell:
     cmd: |
       set -o pipefail
@@ -533,7 +533,7 @@
   when: grafana_setup_discover_amd_gpu_exporters
   failed_when: false
 
-- name: Verify discovered AMD SMI exporters are responding
+- name: Verify discovered AMD Device Metrics exporters are responding
   ansible.builtin.uri:
     url: "http://{{ item }}:{{ grafana_setup_amd_gpu_exporter_port }}/metrics"
     method: GET
@@ -548,7 +548,7 @@
   failed_when: false
   changed_when: false
 
-- name: Build list of verified AMD SMI exporter targets
+- name: Build list of verified AMD Device Metrics exporter targets
   ansible.builtin.set_fact:
     grafana_verified_amd_gpu_targets: >-
       {{ grafana_verified_amd_gpu_exporters.results |
@@ -561,10 +561,10 @@
     - grafana_setup_discover_amd_gpu_exporters
     - grafana_verified_amd_gpu_exporters.results is defined
 
-- name: Display discovered AMD SMI exporters
+- name: Display discovered AMD Device Metrics exporters
   ansible.builtin.debug:
     msg:
-      - "Discovered {{ grafana_verified_amd_gpu_targets | default([]) | length }} AMD SMI exporter(s) on the network"
+      - "Discovered {{ grafana_verified_amd_gpu_targets | default([]) | length }} AMD Device Metrics exporter(s) on the network"
       - "Targets: {{ grafana_verified_amd_gpu_targets | default([]) | join(', ') }}"
       - "Port: {{ grafana_setup_amd_gpu_exporter_port }}"
   when:

--- a/roles/grafana_setup/templates/prometheus.yml.j2
+++ b/roles/grafana_setup/templates/prometheus.yml.j2
@@ -53,7 +53,7 @@ scrape_configs:
           group: 'monitoring'
 
 {% if grafana_verified_amd_gpu_targets is defined and grafana_verified_amd_gpu_targets | length > 0 %}
-  # AMD SMI Exporters (https://github.com/amd/amd_smi_exporter)
+  # AMD Device Metrics Exporters (https://github.com/ROCm/device-metrics-exporter)
   - job_name: 'amd_gpu'
     static_configs:
 {% for target in grafana_verified_amd_gpu_targets %}


### PR DESCRIPTION
… Exporter

Replace generic AMD GPU dashboard (12239) with AMD Instinct Single Node Dashboard (23434) which is specifically designed for AMD Device Metrics Exporter metrics.

Changes:
- Dashboard ID: 12239 → 23434 (AMD Instinct Single Node Dashboard)
- Update all references: AMD SMI Exporter → AMD Device Metrics Exporter
- Update repository links to official ROCm Device Metrics Exporter
- Update supported GPU models: MI100/MI200/MI300 series
- Update all task names to reflect correct exporter name
- Update documentation in README.md and NETWORK_DISCOVERY.md

CI Updates:
- Add new technical terms to .wordlist.txt: Instinct, MI100, MI200, MI300
- All YAML validated, ansible-lint passing
- CI already has discovery disabled, will pass without changes

The new dashboard provides better visualization of:
- GPU utilization and performance metrics
- Temperature and power consumption
- Memory usage and clock speeds
- ROCm-specific telemetry

Discovery feature remains fully functional:
- Scans network for port 2021 (Device Metrics Exporter)
- Verifies /metrics endpoint is responding
- Automatically adds to Prometheus scrape config
- Labels targets with 'discovered: true' and 'group: gpus'

Dashboard URL: http://localhost:3000/d/amd-gpu-metrics
Dashboard Source: https://grafana.com/grafana/dashboards/23434