### PR TITLE
rdma_setup: Make reboot an optional thing

### DIFF
--- a/roles/rdma_setup/defaults/main.yml
+++ b/roles/rdma_setup/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 # defaults file for rdma_setup
+rdma_setup_reboot: false
 rdma_setup_reboot_timeout: 60
 rdma_detect_output_file: /tmp/rdma-detect.status
 rdma_detect_script_dest: /usr/local/bin/rdma-detect

--- a/roles/rdma_setup/hosts-rdma-setup
+++ b/roles/rdma_setup/hosts-rdma-setup
@@ -2,7 +2,13 @@ rdma_servers:
   hosts:
     snoc-think-vm:
         ansible_host: snoc-think
+        ansible_port: 2223
+        rmda_setup_motd: true
+    snoc-think-host-vm:
+        ansible_host: snoc-think
         ansible_port: 2222
+        rmda_setup_motd: true
+        ansible_user: aiseap
     stebates-amd-laptop:
         ansible_connection: local
   vars:

--- a/roles/rdma_setup/tasks/main.yml
+++ b/roles/rdma_setup/tasks/main.yml
@@ -24,7 +24,7 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ rdma_setup_reboot_timeout }}"
   become: true
-  when: ansible_connection != 'local'
+  when: rdma_setup_reboot and ansible_connection != 'local'
 
 - name: Update ansible_kernel as it may have changed
   ansible.builtin.setup:
@@ -68,7 +68,7 @@
   ansible.builtin.reboot:
     reboot_timeout: "{{ rdma_setup_reboot_timeout }}"
   become: true
-  when: ansible_connection != 'local'
+  when: rdma_setup_reboot and ansible_connection != 'local'
 
 - name: Copy rdma-detect script to target host
   ansible.builtin.copy:


### PR DESCRIPTION
We do not always want (or are able to) reboot the host. So we disable reboot by default.