### PR TITLE
linux-generic: Add the meta-package to the install packages

### DIFF
--- a/roles/rocm_setup/tasks/rocm_pre.yml
+++ b/roles/rocm_setup/tasks/rocm_pre.yml
@@ -133,6 +133,7 @@
   ansible.builtin.package:
     update_cache: true
     name:
+      - linux-generic
       - linux-headers-{{ ansible_kernel }}
       - linux-modules-extra-{{ ansible_kernel }}
   become: true


### PR DESCRIPTION
We add the linux-generic meta-package to our installed packages. This ensures that even when the generic kernel is updated we always install the headers and modules-extra packages too.