### PR TITLE
fave_packages: Add linux-generic

### DIFF
--- a/roles/fave_packages/tasks/main.yml
+++ b/roles/fave_packages/tasks/main.yml
@@ -31,6 +31,7 @@
       - gpg-agent
       - libaio-dev
       - liburing-dev
+      - linux-generic
       - prometheus-node-exporter
       - prometheus-node-exporter-collectors
       - python-is-python3


### PR DESCRIPTION
In order to ensure we always have the linux-headers and linux-modules-extra we install linux-generic. This is very useful for a few other tasks so let's do it here.