### PR TITLE
rdma_setup: cleanup README, add optional rdma_exporter install

### DIFF
--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -8,6 +8,7 @@ Compatability
 ConnectX
 Customizable
 DFD
+DGX
 DHCP
 DOM
 DOMs
@@ -28,6 +29,7 @@ InfiniBand
 Instinct
 JSON
 json
+NIC
 URI
 URI
 LTS

--- a/playbooks/hosts-example.yml
+++ b/playbooks/hosts-example.yml
@@ -64,7 +64,7 @@ all:
         nvmeof-hosts:
           nvmeof_setup_mode: host
           ansible_host: snoc-think
-          nvmeof_setup_target_host: 192.168.2.1
+          nvmeof_setup_target_host: 
           nvmeof_setup_connections:
             - transport: rdma
               trsvcid: 4420
@@ -103,3 +103,13 @@ all:
                 - nvmet-storage
       vars:
         username: stebates
+    
+    rdma:
+      hosts:
+        snoc-think:
+          ansible_host: snoc-think
+        snoc-think-vm:
+          ansible_host: snoc-think-vm
+      vars:
+        rdma_setup_install_rdma_exporter: true
+        rdma_setup_motd: true

--- a/roles/rdma_setup/README.md
+++ b/roles/rdma_setup/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-This Ansible role configures RDMA/InfiniBand support on Ubuntu systems. It installs the necessary kernel modules, RDMA packages, and provides comprehensive detection and reporting of RDMA-capable devices.
+This Ansible role configures RDMA/InfiniBand support on Ubuntu systems.
+It installs the necessary kernel modules, RDMA packages, and provides
+comprehensive detection and reporting of RDMA-capable devices.
 
 ## Features
 
@@ -21,7 +23,7 @@ This Ansible role configures RDMA/InfiniBand support on Ubuntu systems. It insta
 
 ## Role Variables
 
-Available variables are listed below, along with default values (see `defaults/main.yml`):
+Available variables are listed below (defaults in `defaults/main.yml`):
 
 ```yaml
 # Timeout for system reboot (in seconds)
@@ -61,6 +63,32 @@ Device:  mlx5_0
 ==========================================
 ```
 
+## Optional: Prometheus rdma_exporter
+
+When enabled, the role can install the [rdma_exporter](https://github.com/yuuki/rdma_exporter)
+Prometheus exporter, which exposes RDMA/InfiniBand/RoCE NIC statistics
+as metrics.
+
+Variables (defaults in `defaults/main.yml`):
+
+- `rdma_setup_install_rdma_exporter` – enable installer (default: false)
+- `rdma_exporter_version` – release version, e.g. `"0.3.0"`
+- `rdma_exporter_install_dir` – binary directory (default: `/usr/local/bin`)
+- `rdma_exporter_listen_address` – listen address (default: `:9879`)
+- `rdma_exporter_metrics_path` – metrics path (default: `/metrics`)
+- `rdma_exporter_health_path` – health path (default: `/healthz`)
+- `rdma_exporter_exclude_devices` – comma-separated devices to exclude
+  (e.g. `mlx5_0,mlx5_1` on DGX/GB200)
+
+Example with exporter and device exclusion:
+
+```yaml
+- role: rdma_setup
+  vars:
+    rdma_setup_install_rdma_exporter: true
+    rdma_exporter_exclude_devices: "mlx5_0,mlx5_1"
+```
+
 ## Dependencies
 
 - Role: `check_platform` - Validates platform compatibility
@@ -89,7 +117,8 @@ After the role runs, you can access the RDMA detection information:
     var: rdma_detection_report
 ```
 
-The report is also saved on the target host at the location specified by `rdma_detect_output_file`.
+The report is also saved on the target host at the location specified
+by `rdma_detect_output_file`.
 
 ## Testing
 
@@ -99,7 +128,8 @@ Run the following from the folder this README resides in:
 ANSIBLE_ROLES_PATH=../ ansible-playbook -i <host_file> ./tests/test.yml
 ```
 
-There is an [example hosts file](./hosts-rdma-setup) that users can use as a template for their testing.
+There is an [example hosts file](./hosts-rdma-setup) that users can use
+as a template for their testing.
 
 ## Installed Packages
 
@@ -115,4 +145,5 @@ The role installs the following packages:
 
 ## Author and License Information
 
-See the [meta file](./meta/main.yml) for more information on the author, licensing and other details.
+See the [meta file](./meta/main.yml) for author, licensing and other
+details.

--- a/roles/rdma_setup/defaults/main.yml
+++ b/roles/rdma_setup/defaults/main.yml
@@ -7,3 +7,12 @@ rdma_detect_script_dest: /usr/local/bin/rdma-detect
 
 # Enable MOTD showing RDMA/InfiniBand devices
 rdma_setup_motd: false
+
+# Optional: install Prometheus rdma_exporter (https://github.com/yuuki/rdma_exporter)
+rdma_setup_install_rdma_exporter: false
+rdma_exporter_version: "0.3.0"
+rdma_exporter_install_dir: "/usr/local/bin"
+rdma_exporter_listen_address: ":9879"
+rdma_exporter_metrics_path: "/metrics"
+rdma_exporter_health_path: "/health"
+rdma_exporter_exclude_devices: ""

--- a/roles/rdma_setup/tasks/main.yml
+++ b/roles/rdma_setup/tasks/main.yml
@@ -20,6 +20,7 @@
     autoremove: true
   become: true
 
+# Reboot after apt upgrade so new kernel (if any) is loaded.
 - name: Perform a reboot to allow kernel updates
   ansible.builtin.reboot:
     reboot_timeout: "{{ rdma_setup_reboot_timeout }}"
@@ -65,6 +66,7 @@
   failed_when: false
   changed_when: false
 
+# Reboot again so RDMA kernel modules can load.
 - name: Perform another reboot to allow modules to load
   ansible.builtin.reboot:
     reboot_timeout: "{{ rdma_setup_reboot_timeout }}"
@@ -106,7 +108,7 @@
 
 - name: Display location of saved report
   ansible.builtin.debug:
-    msg: "RDMA detection report saved to {{ rdma_detect_output_file }} on target host"
+    msg: "RDMA detection report saved to {{ rdma_detect_output_file }}"
 
 - name: Run the rdma dev command and register output
   ansible.builtin.command:
@@ -130,3 +132,7 @@
     mode: '0755'
   become: true
   when: rdma_setup_motd
+
+- name: Install and configure rdma_exporter (optional)
+  ansible.builtin.include_tasks: rdma_exporter.yml
+  when: rdma_setup_install_rdma_exporter | default(false) | bool

--- a/roles/rdma_setup/tasks/rdma_exporter.yml
+++ b/roles/rdma_setup/tasks/rdma_exporter.yml
@@ -1,0 +1,159 @@
+---
+# Optional install of Prometheus rdma_exporter (yuuki/rdma_exporter).
+
+- name: Set rdma_exporter architecture for GitHub asset
+  ansible.builtin.set_fact:
+    rdma_exporter_arch: >-
+      {{ 'amd64' if ansible_architecture == 'x86_64'
+         else 'arm64' if ansible_architecture == 'aarch64'
+         else '' }}
+
+- name: Fail on unsupported architecture for rdma_exporter
+  ansible.builtin.fail:
+    msg: "rdma_exporter not available for arch {{ ansible_architecture }}"
+  when: rdma_exporter_arch == ''
+
+- name: Get latest rdma_exporter version from GitHub API
+  ansible.builtin.uri:
+    url: https://api.github.com/repos/yuuki/rdma_exporter/releases/latest
+    return_content: true
+  register: rdma_exporter_latest_release
+  when: rdma_exporter_version == "latest"
+  changed_when: false
+
+- name: Set rdma_exporter resolved version
+  ansible.builtin.set_fact:
+    rdma_exporter_resolved_version: >-
+      {{ (rdma_exporter_latest_release.json.tag_name | regex_replace('^v', ''))
+         if rdma_exporter_version == 'latest'
+         else rdma_exporter_version }}
+
+- name: Check if rdma_exporter binary is present
+  ansible.builtin.stat:
+    path: "{{ rdma_exporter_install_dir }}/rdma_exporter"
+  register: rdma_exporter_binary_stat
+
+- name: Check if rdma_exporter version file is present
+  ansible.builtin.stat:
+    path: "{{ rdma_exporter_install_dir }}/.rdma_exporter_version"
+  register: rdma_exporter_version_file_stat
+
+- name: Read installed rdma_exporter version
+  ansible.builtin.slurp:
+    src: "{{ rdma_exporter_install_dir }}/.rdma_exporter_version"
+  register: rdma_exporter_version_content
+  when: rdma_exporter_version_file_stat.stat.exists
+  become: true
+
+- name: Set current rdma_exporter version fact
+  ansible.builtin.set_fact:
+    rdma_exporter_current_version: >-
+      {{ rdma_exporter_version_content.content | b64decode | trim }}
+  when: >-
+    rdma_exporter_version_file_stat.stat.exists and
+    not (rdma_exporter_version_content.failed | default(false))
+
+- name: Set rdma_exporter download URL
+  ansible.builtin.set_fact:
+    rdma_exporter_download_url: >-
+      {{ 'https://github.com/yuuki/rdma_exporter/releases/download/v'
+         ~ rdma_exporter_resolved_version
+         ~ '/rdma_exporter_' ~ rdma_exporter_resolved_version
+         ~ '_linux_' ~ rdma_exporter_arch ~ '.tar.gz' }}
+
+- name: Download and install rdma_exporter binary
+  when: >-
+    not rdma_exporter_binary_stat.stat.exists or
+    not rdma_exporter_version_file_stat.stat.exists or
+    (rdma_exporter_current_version | default('')) != rdma_exporter_resolved_version
+  block:
+    - name: Create temporary directory for download
+      ansible.builtin.tempfile:
+        state: directory
+        suffix: rdma_exporter
+      register: rdma_exporter_temp_dir
+
+    - name: Download rdma_exporter release tarball
+      ansible.builtin.get_url:
+        url: "{{ rdma_exporter_download_url }}"
+        dest: "{{ rdma_exporter_temp_dir.path }}/rdma_exporter.tar.gz"
+        mode: '0644'
+
+    - name: Unarchive rdma_exporter tarball
+      ansible.builtin.unarchive:
+        src: "{{ rdma_exporter_temp_dir.path }}/rdma_exporter.tar.gz"
+        dest: "{{ rdma_exporter_temp_dir.path }}"
+        remote_src: true
+      become: true
+
+    - name: Ensure rdma_exporter install directory exists
+      ansible.builtin.file:
+        path: "{{ rdma_exporter_install_dir }}"
+        state: directory
+        mode: '0755'
+      become: true
+
+    - name: Copy rdma_exporter binary to install directory
+      ansible.builtin.copy:
+        src: "{{ rdma_exporter_temp_dir.path }}/rdma_exporter"
+        dest: "{{ rdma_exporter_install_dir }}/rdma_exporter"
+        mode: '0755'
+        owner: root
+        group: root
+        remote_src: true
+      become: true
+
+    - name: Write rdma_exporter version file
+      ansible.builtin.copy:
+        content: "{{ rdma_exporter_resolved_version }}\n"
+        dest: "{{ rdma_exporter_install_dir }}/.rdma_exporter_version"
+        mode: '0644'
+        owner: root
+        group: root
+      become: true
+
+    - name: Remove temporary directory
+      ansible.builtin.file:
+        path: "{{ rdma_exporter_temp_dir.path }}"
+        state: absent
+      become: true
+
+- name: Deploy rdma_exporter environment file
+  ansible.builtin.template:
+    src: rdma_exporter.env.j2
+    dest: /etc/rdma_exporter.env
+    owner: root
+    group: root
+    mode: '0640'
+  become: true
+
+- name: Stop and remove old rdma_exporter unit if present
+  ansible.builtin.systemd:
+    name: rdma_exporter
+    state: stopped
+    enabled: false
+  become: true
+  failed_when: false
+
+- name: Remove old rdma_exporter unit file
+  ansible.builtin.file:
+    path: /etc/systemd/system/rdma_exporter.service
+    state: absent
+  become: true
+
+- name: Deploy rdma-exporter systemd unit
+  ansible.builtin.template:
+    src: rdma_exporter.service.j2
+    dest: /etc/systemd/system/rdma-exporter.service
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+- name: Reload systemd and enable rdma-exporter
+  ansible.builtin.systemd:
+    name: rdma-exporter
+    state: started
+    enabled: true
+    daemon_reload: true
+  become: true

--- a/roles/rdma_setup/templates/rdma_exporter.env.j2
+++ b/roles/rdma_setup/templates/rdma_exporter.env.j2
@@ -1,0 +1,7 @@
+# Managed by Ansible - rdma_setup role
+RDMA_EXPORTER_LISTEN_ADDRESS={{ rdma_exporter_listen_address }}
+RDMA_EXPORTER_METRICS_PATH={{ rdma_exporter_metrics_path }}
+RDMA_EXPORTER_HEALTH_PATH={{ rdma_exporter_health_path }}
+{% if rdma_exporter_exclude_devices | default('') | length > 0 %}
+RDMA_EXPORTER_EXCLUDE_DEVICES={{ rdma_exporter_exclude_devices }}
+{% endif %}

--- a/roles/rdma_setup/templates/rdma_exporter.service.j2
+++ b/roles/rdma_setup/templates/rdma_exporter.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=Prometheus RDMA Exporter
+Documentation=https://github.com/yuuki/rdma_exporter
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+EnvironmentFile=-/etc/rdma_exporter.env
+ExecStart={{ rdma_exporter_install_dir }}/rdma_exporter \
+  --listen-address={{ rdma_exporter_listen_address }} \
+  --metrics-path={{ rdma_exporter_metrics_path }} \
+  --health-path={{ rdma_exporter_health_path }}
+Restart=on-failure
+RestartSec=5s
+StateDirectory=rdma-exporter
+RuntimeDirectory=rdma-exporter
+WorkingDirectory=/var/lib/rdma-exporter
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
- Enforce 80-column limit in README (overview, variables, report path, hosts file, meta); add Optional: Prometheus rdma_exporter section with variables and example.
- Add brief comments above the two reboot steps in tasks/main.yml; shorten debug message for saved report location.
- Add optional install of yuuki/rdma_exporter: new defaults (rdma_setup_install_rdma_exporter, version, install_dir, listen, paths, exclude_devices); tasks/rdma_exporter.yml for download from GitHub releases, binary install, systemd unit and env file; support x86_64/amd64 and aarch64/arm64; idempotent via version file.
- Add templates: rdma_exporter.service.j2, rdma_exporter.env.j2.

Exporter is disabled by default; enable with
rdma_setup_install_rdma_exporter: true.