### PR TITLE
rdma_setup, rocm_setup: Replace apt dist-upgrade with safe upgrade

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: sbates130272
 name: batesste
-version: 1.1.0
+version: 1.1.1
 readme: README.md
 
 authors:

--- a/roles/rdma_setup/tasks/main.yml
+++ b/roles/rdma_setup/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Perform an update, upgrade and autoremove
   ansible.builtin.apt:
     update_cache: true
-    upgrade: full
+    upgrade: safe
     autoremove: true
   become: true
   register: rdma_setup_apt_result

--- a/roles/rocm_setup/tasks/rocm_pre.yml
+++ b/roles/rocm_setup/tasks/rocm_pre.yml
@@ -182,7 +182,7 @@
 - name: Perform an update, upgrade and autoremove
   ansible.builtin.apt:
     update_cache: true
-    upgrade: full
+    upgrade: safe
     autoremove: true
   become: true
 


### PR DESCRIPTION
The `upgrade: full` setting (equivalent to apt-get dist-upgrade) can remove installed packages to resolve dependency conflicts, causing breakage in CI and on real hosts. Switch both roles to `upgrade: safe` which upgrades packages without removing any.

Bump collection version to 1.1.1.