### PR TITLE
Add Ubuntu 26.04 coverage to generated role CI workflows

### DIFF
--- a/.github/generate-workflows.py
+++ b/.github/generate-workflows.py
@@ -201,6 +201,7 @@ def generate_workflow_yaml(role_name: str, config: Dict) -> str:
     # Add matrix or single runner
     if use_matrix:
         lines.append("    strategy:")
+        lines.append("      fail-fast: false")
         lines.append("      matrix:")
         lines.append("        runs-on:")
         for version in ubuntu_versions:

--- a/.github/generate-workflows.py
+++ b/.github/generate-workflows.py
@@ -144,7 +144,7 @@ WORKFLOW_DISPATCH_ONLY_ROLES: List[str] = []  # e.g. ["nvmeof_setup"]
 
 # Default configuration for roles without specific config
 DEFAULT_CONFIG = {
-    "ubuntu_versions": ["24.04"],
+    "ubuntu_versions": ["24.04", "26.04"],
     "free_disk_space": False,
     "extra_vars": {},
     "verification_commands": [],
@@ -206,7 +206,7 @@ def generate_workflow_yaml(role_name: str, config: Dict) -> str:
         for version in ubuntu_versions:
             lines.append(f"          - ubuntu-{version}")
         lines.append("    runs-on: ${{ matrix.runs-on }}")
-        if "26.04" in ubuntu_versions:
+        if "26.04" in ubuntu_versions and not config.get("ignore_failure", False):
             lines.append(
                 "    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}"
             )

--- a/.github/generate-workflows.py
+++ b/.github/generate-workflows.py
@@ -207,6 +207,10 @@ def generate_workflow_yaml(role_name: str, config: Dict) -> str:
         for version in ubuntu_versions:
             lines.append(f"          - ubuntu-{version}")
         lines.append("    runs-on: ${{ matrix.runs-on }}")
+        if "26.04" in ubuntu_versions:
+            lines.append(
+                "    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}"
+            )
         if "26.04" in ubuntu_versions and not config.get("ignore_failure", False):
             lines.append(
                 "    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}"

--- a/.github/workflows/git_setup-ci.yml
+++ b/.github/workflows/git_setup-ci.yml
@@ -17,6 +17,7 @@ name: git_setup CI
 jobs:
   git_setup-test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04

--- a/.github/workflows/git_setup-ci.yml
+++ b/.github/workflows/git_setup-ci.yml
@@ -23,6 +23,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/git_setup-ci.yml
+++ b/.github/workflows/git_setup-ci.yml
@@ -16,7 +16,13 @@ name: git_setup CI
 
 jobs:
   git_setup-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/github_runner-ci.yml
+++ b/.github/workflows/github_runner-ci.yml
@@ -23,6 +23,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/github_runner-ci.yml
+++ b/.github/workflows/github_runner-ci.yml
@@ -16,7 +16,13 @@ name: github_runner CI
 
 jobs:
   github_runner-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/github_runner-ci.yml
+++ b/.github/workflows/github_runner-ci.yml
@@ -17,6 +17,7 @@ name: github_runner CI
 jobs:
   github_runner-test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04

--- a/.github/workflows/grafana_setup-ci.yml
+++ b/.github/workflows/grafana_setup-ci.yml
@@ -23,6 +23,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/grafana_setup-ci.yml
+++ b/.github/workflows/grafana_setup-ci.yml
@@ -16,7 +16,13 @@ name: grafana_setup CI
 
 jobs:
   grafana_setup-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/grafana_setup-ci.yml
+++ b/.github/workflows/grafana_setup-ci.yml
@@ -17,6 +17,7 @@ name: grafana_setup CI
 jobs:
   grafana_setup-test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04

--- a/.github/workflows/mutt_setup-ci.yml
+++ b/.github/workflows/mutt_setup-ci.yml
@@ -23,6 +23,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/mutt_setup-ci.yml
+++ b/.github/workflows/mutt_setup-ci.yml
@@ -17,6 +17,7 @@ name: mutt_setup CI
 jobs:
   mutt_setup-test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04

--- a/.github/workflows/mutt_setup-ci.yml
+++ b/.github/workflows/mutt_setup-ci.yml
@@ -16,7 +16,13 @@ name: mutt_setup CI
 
 jobs:
   mutt_setup-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/nvme_exporter_setup-ci.yml
+++ b/.github/workflows/nvme_exporter_setup-ci.yml
@@ -23,6 +23,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/nvme_exporter_setup-ci.yml
+++ b/.github/workflows/nvme_exporter_setup-ci.yml
@@ -17,6 +17,7 @@ name: nvme_exporter_setup CI
 jobs:
   nvme_exporter_setup-test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04

--- a/.github/workflows/nvme_exporter_setup-ci.yml
+++ b/.github/workflows/nvme_exporter_setup-ci.yml
@@ -16,7 +16,13 @@ name: nvme_exporter_setup CI
 
 jobs:
   nvme_exporter_setup-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/nvmeof_setup-ci.yml
+++ b/.github/workflows/nvmeof_setup-ci.yml
@@ -10,6 +10,7 @@ jobs:
   nvmeof_setup-test:
     continue-on-error: true
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04

--- a/.github/workflows/nvmeof_setup-ci.yml
+++ b/.github/workflows/nvmeof_setup-ci.yml
@@ -9,7 +9,12 @@ name: nvmeof_setup CI
 jobs:
   nvmeof_setup-test:
     continue-on-error: true
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/nvmeof_setup-ci.yml
+++ b/.github/workflows/nvmeof_setup-ci.yml
@@ -16,6 +16,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/rdma_setup-ci.yml
+++ b/.github/workflows/rdma_setup-ci.yml
@@ -23,6 +23,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/rdma_setup-ci.yml
+++ b/.github/workflows/rdma_setup-ci.yml
@@ -16,7 +16,13 @@ name: rdma_setup CI
 
 jobs:
   rdma_setup-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/rdma_setup-ci.yml
+++ b/.github/workflows/rdma_setup-ci.yml
@@ -17,6 +17,7 @@ name: rdma_setup CI
 jobs:
   rdma_setup-test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04

--- a/.github/workflows/rocm_setup-ci.yml
+++ b/.github/workflows/rocm_setup-ci.yml
@@ -17,6 +17,7 @@ name: rocm_setup CI
 jobs:
   rocm_setup-test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04

--- a/.github/workflows/rocm_setup-ci.yml
+++ b/.github/workflows/rocm_setup-ci.yml
@@ -23,6 +23,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Free Disk Space (Ubuntu)

--- a/.github/workflows/rocm_setup-ci.yml
+++ b/.github/workflows/rocm_setup-ci.yml
@@ -16,7 +16,13 @@ name: rocm_setup CI
 
 jobs:
   rocm_setup-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Free Disk Space (Ubuntu)
         uses: jlumbroso/free-disk-space@v1.3.1

--- a/.github/workflows/uprof_setup-ci.yml
+++ b/.github/workflows/uprof_setup-ci.yml
@@ -15,6 +15,7 @@ jobs:
           - ubuntu-24.04
           - ubuntu-26.04
     runs-on: ${{ matrix.runs-on }}
+    if: ${{ matrix.runs-on != 'ubuntu-26.04' || vars.ENABLE_UBUNTU_2604 == 'true' }}
     continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code

--- a/.github/workflows/uprof_setup-ci.yml
+++ b/.github/workflows/uprof_setup-ci.yml
@@ -8,7 +8,13 @@ name: uprof_setup CI
 
 jobs:
   uprof_setup-test:
-    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        runs-on:
+          - ubuntu-24.04
+          - ubuntu-26.04
+    runs-on: ${{ matrix.runs-on }}
+    continue-on-error: ${{ matrix.runs-on == 'ubuntu-26.04' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/uprof_setup-ci.yml
+++ b/.github/workflows/uprof_setup-ci.yml
@@ -9,6 +9,7 @@ name: uprof_setup CI
 jobs:
   uprof_setup-test:
     strategy:
+      fail-fast: false
       matrix:
         runs-on:
           - ubuntu-24.04


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update workflow generation defaults to test role workflows on Ubuntu 24.04 and 26.04
- regenerate all auto-generated role CI workflow files to include a 2-version matrix
- disable matrix fail-fast so both Ubuntu legs always run and report independently
- temporarily skip ubuntu-26.04 matrix legs by default to avoid 24h queue timeouts while GitHub-hosted 26.04 runners are unavailable
- add a repository-variable toggle to re-enable 26.04 legs without code changes (`ENABLE_UBUNTU_2604=true`)
- keep `ignore_failure` behavior intact for special roles while avoiding duplicate `continue-on-error` keys

## Validation
- `python3 .github/generate-workflows.py`
- `python3 -m py_compile .github/generate-workflows.py`
- `git diff --check`

## Notes
- this change targets role-level generated workflows only
- manually maintained workflows (for example `batesste-ansible-ci.yml`) were intentionally left unchanged
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d1cba060-028e-4a46-94ba-0b560bccb1fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1cba060-028e-4a46-94ba-0b560bccb1fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

