### PR TITLE
Pin Grafana to 13.0.1 and limit role CI to relevant changes

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -109,11 +109,10 @@ These are configured via the `extra_vars` in each role's configuration.
 Individual role workflows trigger on:
 - Manual dispatch (`workflow_dispatch`)
 - Pull requests to `main` branch (when role files change)
-- Pushes to `main` branch (when role files change)
 
 Path filters ensure workflows only run when relevant files are modified:
 - `roles/{role_name}/**`
-- `.github/workflows/**`
+- `.github/workflows/{role_name}-ci.yml`
 - `requirements.txt`
 - `requirements.yml`
 

--- a/.github/generate-workflows.py
+++ b/.github/generate-workflows.py
@@ -206,7 +206,7 @@ def generate_workflow_yaml(role_name: str, config: Dict) -> str:
             "      - main",
             "    paths:",
             f"      - roles/{role_name}/**",
-            "      - .github/workflows/**",
+            f"      - .github/workflows/{role_name}-ci.yml",
             "      - requirements.txt",
             "      - requirements.yml",
         ])

--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -23,6 +23,30 @@ on:
 
 jobs:
 
+  detect-role-changes:
+    runs-on: ubuntu-24.04
+    outputs:
+      rocm_setup: ${{ steps.filter.outputs.rocm_setup }}
+      grafana_setup: ${{ steps.filter.outputs.grafana_setup }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.2.2
+      - name: Detect changed role files
+        id: filter
+        uses: dorny/paths-filter@v3.0.2
+        with:
+          filters: |
+            rocm_setup:
+              - 'roles/rocm_setup/**'
+              - 'requirements.txt'
+              - 'requirements.yml'
+              - '.github/workflows/batesste-ansible-ci.yml'
+            grafana_setup:
+              - 'roles/grafana_setup/**'
+              - 'requirements.txt'
+              - 'requirements.yml'
+              - '.github/workflows/batesste-ansible-ci.yml'
+
   build-spellcheck-lint-test:
     runs-on: ubuntu-24.04
     steps:
@@ -77,6 +101,10 @@ jobs:
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 
   rocm_setup-role-test:
+    needs: detect-role-changes
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+      needs.detect-role-changes.outputs.rocm_setup == 'true' }}
     strategy:
       matrix:
         include:
@@ -129,6 +157,10 @@ jobs:
           ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
 
   grafana_setup-role-test:
+    needs: detect-role-changes
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' ||
+      needs.detect-role-changes.outputs.grafana_setup == 'true' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code

--- a/.github/workflows/git_setup-ci.yml
+++ b/.github/workflows/git_setup-ci.yml
@@ -10,7 +10,7 @@ name: git_setup CI
       - main
     paths:
       - roles/git_setup/**
-      - .github/workflows/**
+      - .github/workflows/git_setup-ci.yml
       - requirements.txt
       - requirements.yml
 

--- a/.github/workflows/github_runner-ci.yml
+++ b/.github/workflows/github_runner-ci.yml
@@ -10,7 +10,7 @@ name: github_runner CI
       - main
     paths:
       - roles/github_runner/**
-      - .github/workflows/**
+      - .github/workflows/github_runner-ci.yml
       - requirements.txt
       - requirements.yml
 

--- a/.github/workflows/grafana_setup-ci.yml
+++ b/.github/workflows/grafana_setup-ci.yml
@@ -10,7 +10,7 @@ name: grafana_setup CI
       - main
     paths:
       - roles/grafana_setup/**
-      - .github/workflows/**
+      - .github/workflows/grafana_setup-ci.yml
       - requirements.txt
       - requirements.yml
 

--- a/.github/workflows/lemonade_setup-ci.yml
+++ b/.github/workflows/lemonade_setup-ci.yml
@@ -10,7 +10,7 @@ name: lemonade_setup CI
       - main
     paths:
       - roles/lemonade_setup/**
-      - .github/workflows/**
+      - .github/workflows/lemonade_setup-ci.yml
       - requirements.txt
       - requirements.yml
 

--- a/.github/workflows/mutt_setup-ci.yml
+++ b/.github/workflows/mutt_setup-ci.yml
@@ -10,7 +10,7 @@ name: mutt_setup CI
       - main
     paths:
       - roles/mutt_setup/**
-      - .github/workflows/**
+      - .github/workflows/mutt_setup-ci.yml
       - requirements.txt
       - requirements.yml
 

--- a/.github/workflows/nvme_exporter_setup-ci.yml
+++ b/.github/workflows/nvme_exporter_setup-ci.yml
@@ -10,7 +10,7 @@ name: nvme_exporter_setup CI
       - main
     paths:
       - roles/nvme_exporter_setup/**
-      - .github/workflows/**
+      - .github/workflows/nvme_exporter_setup-ci.yml
       - requirements.txt
       - requirements.yml
 

--- a/.github/workflows/rdma_setup-ci.yml
+++ b/.github/workflows/rdma_setup-ci.yml
@@ -10,7 +10,7 @@ name: rdma_setup CI
       - main
     paths:
       - roles/rdma_setup/**
-      - .github/workflows/**
+      - .github/workflows/rdma_setup-ci.yml
       - requirements.txt
       - requirements.yml
 

--- a/.github/workflows/rocm_setup-ci.yml
+++ b/.github/workflows/rocm_setup-ci.yml
@@ -10,7 +10,7 @@ name: rocm_setup CI
       - main
     paths:
       - roles/rocm_setup/**
-      - .github/workflows/**
+      - .github/workflows/rocm_setup-ci.yml
       - requirements.txt
       - requirements.yml
 

--- a/roles/grafana_setup/README.md
+++ b/roles/grafana_setup/README.md
@@ -26,7 +26,7 @@ Available variables are listed below, along with default values (see `defaults/m
 
 ```yaml
 # Grafana package version (apt). Pin to avoid surprise upgrades.
-grafana_setup_version: "13.0.0"
+grafana_setup_version: "13.0.1"
 
 # Grafana configuration
 # Note: Grafana's default admin username is always 'admin'

--- a/roles/grafana_setup/defaults/main.yml
+++ b/roles/grafana_setup/defaults/main.yml
@@ -3,7 +3,7 @@
 
 # Grafana package version (apt). Pin to avoid surprise upgrades.
 # grafana-cli was removed in v13.0; the role now uses "grafana cli".
-grafana_setup_version: "13.0.0"
+grafana_setup_version: "13.0.1"
 
 # Grafana configuration
 # Note: Grafana's default admin username is always 'admin'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- pin `grafana_setup` to Grafana package version `13.0.1`
- update role CI workflow generation so each role workflow only triggers from:
  - that role's files
  - its own workflow file
  - `requirements.txt` / `requirements.yml`
- update the main CI workflow to skip `rocm_setup-role-test` and `grafana_setup-role-test` unless their role-relevant files changed (while still running on manual dispatch)
- refresh generated role workflow files and docs to match the new trigger behavior

## What changed
### Grafana pin
- `roles/grafana_setup/defaults/main.yml`
  - `grafana_setup_version` changed from `13.0.0` to `13.0.1`
- `roles/grafana_setup/README.md`
  - updated documented default to `13.0.1`

### Role workflow trigger scoping
- `.github/generate-workflows.py`
  - narrowed trigger path from `.github/workflows/**` to `.github/workflows/{role_name}-ci.yml`
  - prevents unrelated role workflow runs when other workflow files change
- regenerated all role CI workflow files under `.github/workflows/*-ci.yml`

### Main workflow role-job gating
- `.github/workflows/batesste-ansible-ci.yml`
  - added `detect-role-changes` job using `dorny/paths-filter@v3.0.2`
  - gated:
    - `rocm_setup-role-test`
    - `grafana_setup-role-test`
  - jobs now run only when their role-related files changed, or always on `workflow_dispatch`

### Docs sync
- `.github/README.md`
  - updated trigger documentation to match generated role workflow behavior

## Validation
- regenerated workflows via:
  - `python3 .github/generate-workflows.py`
- validated workflow YAML parse for all CI workflow files using `yaml.safe_load`.
- verified no remaining `13.0.0` references.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5460f261-d65e-4667-aa7e-726415a19db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5460f261-d65e-4667-aa7e-726415a19db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

