### PR TITLE
release: bump collection to 1.4.0 with ROCDXG WSL support

### DIFF
--- a/.github/generate-workflows.py
+++ b/.github/generate-workflows.py
@@ -28,7 +28,7 @@ ROLE_CONFIGS = {
     "rocm_setup": {
         "free_disk_space": True,
         "extra_vars": {
-            "rocm_setup_wsl_install": False,
+            "rocm_setup_wsl": False,
             "rocm_setup_rocm_version": "latest",
             "rocm_setup_amdgpu_version": "latest",
             "rocm_setup_run_checks": False,
@@ -45,7 +45,7 @@ ROLE_CONFIGS = {
     "rocm_xio_setup": {
         "free_disk_space": True,
         "extra_vars": {
-            "rocm_setup_wsl_install": False,
+            "rocm_setup_wsl": False,
             "rocm_setup_rocm_version": "latest",
             "rocm_setup_amdgpu_version": "latest",
             "rocm_setup_run_checks": False,
@@ -65,16 +65,18 @@ ROLE_CONFIGS = {
         "needs_vault": True,
     },
     "rocm_hipfile_setup": {
-        "free_disk_space": False,
+        "free_disk_space": True,
         "extra_vars": {
             "rocm_hipfile_setup_install": True,
             "rocm_hipfile_setup_run_checks": False,
             "rocm_setup_rocm_version": "latest",
             "rocm_setup_amdgpu_version": "latest",
-            "rocm_setup_wsl_install": False,
+            "rocm_setup_wsl": False,
             "rocm_setup_run_checks": False,
             "rocm_setup_install_metrics_exporter": False,
+            "rocm_setup_install_kernel_driver": False,
             "rocm_setup_skip_reboot": True,
+            "rocm_setup_skip_system_upgrade": True,
         },
         "verification_commands": [],
         "needs_vault": False,

--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -113,10 +113,11 @@ jobs:
       matrix:
         include:
           - rocm_version: 7.2
-            wsl_install: false
+            wsl_mode: false
             runs-on: ubuntu-24.04
+          # Legacy roc4wsl path only; rocdxg requires WSL2 + Windows SDK (manual).
           - rocm_version: 7.2
-            wsl_install: true
+            wsl_mode: legacy
             runs-on: ubuntu-24.04
     runs-on: ${{ matrix.runs-on }}
     steps:
@@ -145,7 +146,7 @@ jobs:
             hosts:
               runners:
                 localhost:
-                  rocm_setup_wsl_install: ${{ matrix.wsl_install }}
+                  rocm_setup_wsl: ${{ matrix.wsl_mode }}
                   rocm_setup_rocm_version: ${{ matrix.rocm_version }}
                   rocm_setup_amdgpu_version: ${{ matrix.rocm_version }}
                   rocm_setup_run_checks: false

--- a/.github/workflows/rocm_hipfile_setup-ci.yml
+++ b/.github/workflows/rocm_hipfile_setup-ci.yml
@@ -18,6 +18,8 @@ jobs:
   rocm_hipfile_setup-test:
     runs-on: ubuntu-24.04
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@v1.3.1
       - name: Checkout code
         uses: actions/checkout@v4.2.2
 
@@ -53,10 +55,12 @@ jobs:
                   rocm_hipfile_setup_run_checks: false
                   rocm_setup_rocm_version: latest
                   rocm_setup_amdgpu_version: latest
-                  rocm_setup_wsl_install: false
+                  rocm_setup_wsl: false
                   rocm_setup_run_checks: false
                   rocm_setup_install_metrics_exporter: false
+                  rocm_setup_install_kernel_driver: false
                   rocm_setup_skip_reboot: true
+                  rocm_setup_skip_system_upgrade: true
 
       - name: Run the test playbook against the local runner
         run: ansible-playbook -v -i hosts-ci ./tests/test.yml

--- a/.github/workflows/rocm_setup-ci.yml
+++ b/.github/workflows/rocm_setup-ci.yml
@@ -51,7 +51,7 @@ jobs:
                 localhost:
                   ansible_connection: local
                   ansible_user: runner
-                  rocm_setup_wsl_install: false
+                  rocm_setup_wsl: false
                   rocm_setup_rocm_version: latest
                   rocm_setup_amdgpu_version: latest
                   rocm_setup_run_checks: false

--- a/.github/workflows/rocm_xio_setup-ci.yml
+++ b/.github/workflows/rocm_xio_setup-ci.yml
@@ -51,7 +51,7 @@ jobs:
                 localhost:
                   ansible_connection: local
                   ansible_user: runner
-                  rocm_setup_wsl_install: false
+                  rocm_setup_wsl: false
                   rocm_setup_rocm_version: latest
                   rocm_setup_amdgpu_version: latest
                   rocm_setup_run_checks: false

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -66,17 +66,21 @@ Passthrough
 Pre
 Qwen
 Prometheus
+PowerShell
 RDMA
 README
 ROCm
+ROCDXG
 RTX
 Radeon
 RoCE
 SMI
+SDK
 SSDs
 SSD
 Subnet
 UFW
+UAC
 UI
 URI
 VM
@@ -127,6 +131,7 @@ dmesg
 dnsmasq
 dri
 driverctl
+dxg
 eideticom
 elpa
 emacs
@@ -151,6 +156,7 @@ gpg
 gpu
 gpus
 grafana
+gfx
 hardcode
 hardcoded
 hardcoding
@@ -180,6 +186,7 @@ libpci
 libssl
 liburing
 libvirt
+librocdxg
 lemonade
 llamacpp
 llm
@@ -239,6 +246,8 @@ rdma
 rebase
 repo
 repos
+roc
+rocdxg
 rf
 rocm
 rocminfo
@@ -249,6 +258,7 @@ sbates
 scrapable
 scrape
 scraping
+sdk
 sha
 signingkey
 signup
@@ -293,7 +303,9 @@ vm
 workflow
 workflows
 WiFi
+WindowsSDK
 wifi
+winget
 wsl
 xio
 XIO

--- a/changelogs/fragments/rocm-setup-wsl-rocdxg.yml
+++ b/changelogs/fragments/rocm-setup-wsl-rocdxg.yml
@@ -1,0 +1,12 @@
+---
+# Copyright (c) Stephen Bates, 2026
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+minor_changes:
+  - >-
+    rocm_setup — add ``rocm_setup_wsl`` enum (``false``, ``legacy``,
+    ``rocdxg``) for WSL installs. The ``rocdxg`` mode installs standard ROCm
+    packages, builds librocdxg from source, and configures ROCDXG environment
+    variables for HIP workloads on WSL2. ``rocm_setup_wsl_install`` remains as
+    a deprecated alias for ``legacy``.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: sbates130272
 name: batesste
-version: 1.3.0
+version: 1.4.0
 readme: README.md
 
 authors:

--- a/playbooks/hosts.yml
+++ b/playbooks/hosts.yml
@@ -83,7 +83,11 @@ all:
         amd-laptop:
           ansible_host: 10.0.0.107
           ansible_user: stebates
-          rocm_setup_wsl_install: true
+          username: stebates
+          rocm_setup_wsl: rocdxg
+          rocm_setup_run_checks: true
+          rocm_setup_wsl_run_hip_check: true
+          rocm_setup_install_metrics_exporter: true
         amd-oracle:
           ansible_host: amd-oracle
           user_setup_create: false

--- a/roles/rocm_hipfile_setup/tests/test.yml
+++ b/roles/rocm_hipfile_setup/tests/test.yml
@@ -6,7 +6,9 @@
       become: false
       rocm_setup_run_checks: false
       rocm_setup_install_metrics_exporter: false
+      rocm_setup_install_kernel_driver: false
       rocm_setup_skip_reboot: true
+      rocm_setup_skip_system_upgrade: true
     - role: rocm_hipfile_setup
       become: false
       rocm_hipfile_setup_run_checks: false

--- a/roles/rocm_setup/README.md
+++ b/roles/rocm_setup/README.md
@@ -35,8 +35,22 @@ rocm_setup_reboot_timeout: 300
 # Skip reboot steps (useful for CI, containers, or manual control)
 rocm_setup_skip_reboot: true
 
-# Windows Subsystem for Linux installation
+# WSL install mode: false (Linux), legacy (roc4wsl), or rocdxg (librocdxg)
+rocm_setup_wsl: false
+
+# Deprecated: true maps to legacy when rocm_setup_wsl is false
 rocm_setup_wsl_install: false
+
+# ROCDXG settings (when rocm_setup_wsl: rocdxg)
+rocm_setup_wsl_librocdxg_repo: https://github.com/ROCm/librocdxg.git
+rocm_setup_wsl_librocdxg_version: develop
+rocm_setup_wsl_win_sdk_path: ""
+rocm_setup_wsl_install_win_sdk: true
+rocm_setup_wsl_win_sdk_winget_id: Microsoft.WindowsSDK.10.0.26100
+rocm_setup_wsl_hsa_enable_dxg_detection: true
+rocm_setup_wsl_hsa_override_gfx_version: ""
+rocm_setup_wsl_librocdxg_force: false
+rocm_setup_wsl_run_hip_check: true
 
 # Run ROCm checks (rocminfo and HIP compilation)
 # Set to false in CI or when no AMD GPUs are present
@@ -57,6 +71,88 @@ rocm_setup_extra_kernel_packages: []
 Set `rocm_setup_extra_kernel_packages` from inventory when a target host needs
 kernel-specific packages before `amdgpu-dkms`, such as `linux-modules-extra-aws`
 on EC2.
+
+## WSL support
+
+Set `rocm_setup_wsl` to choose how ROCm is installed on
+[WSL-based systems][ref-wsl]:
+
+| Value | Description |
+| ----- | ----------- |
+| `false` | Standard Linux install (default) |
+| `legacy` | Legacy roc4wsl packages (`hsa-runtime-rocr4wsl-amdgpu`) |
+| `rocdxg` | ROCDXG path: standard ROCm apt packages plus [librocdxg][ref-librocdxg] |
+
+For new WSL hosts, prefer `rocm_setup_wsl: rocdxg`. This follows AMD's
+[ROCDXG WSL guide][ref-wsl-rocdxg]: install Adrenalin 26.2.2+ on Windows,
+then let the role install the Windows SDK (via winget), build librocdxg, and
+configure `HSA_ENABLE_DXG_DETECTION` (for ROCm releases before 7.13).
+
+### Windows SDK (ROCDXG only)
+
+[librocdxg][ref-librocdxg] needs Windows SDK **headers** on the Windows host
+(not a Linux package). The role can install them from WSL by calling
+`powershell.exe winget install` when `rocm_setup_wsl_install_win_sdk` is
+`true` (default).
+
+**Manual install** (elevated PowerShell on Windows):
+
+```powershell
+winget install Microsoft.WindowsSDK.10.0.26100 `
+  --accept-package-agreements --accept-source-agreements
+```
+
+Or download the installer from the [Windows SDK page][ref-win-sdk].
+
+**From WSL** (same command, works if winget is on PATH in PowerShell):
+
+```bash
+powershell.exe -Command "winget install Microsoft.WindowsSDK.10.0.26100 --accept-package-agreements --accept-source-agreements"
+```
+
+winget usually needs an **elevated** Windows session. If the role's automatic
+install fails (common over SSH with no UAC prompt), run the command once in
+"Run as administrator" PowerShell on Windows, then re-run Ansible.
+
+Override the winget package id or disable auto-install:
+
+```yaml
+rocm_setup_wsl_install_win_sdk: true
+rocm_setup_wsl_win_sdk_winget_id: Microsoft.WindowsSDK.10.0.26100
+# Or pin the detected Include path after manual install:
+# rocm_setup_wsl_win_sdk_path: >-
+#   /mnt/c/Program Files (x86)/Windows Kits/10/Include/10.0.26100.0
+```
+
+`rocm_setup_wsl_install: true` remains supported but is deprecated; it maps to
+`legacy` when `rocm_setup_wsl` is unset.
+
+Example inventory for a WSL laptop with HIP workloads:
+
+```yaml
+amd-laptop:
+  ansible_host: 10.0.0.107
+  ansible_user: stebates
+  rocm_setup_wsl: rocdxg
+  rocm_setup_install_metrics_exporter: false
+  # Optional for some APUs (e.g. Strix Halo):
+  # rocm_setup_wsl_hsa_override_gfx_version: "11.0.0"
+```
+
+ROCDXG installs are not exercised in CI (no `/dev/dxg` or Windows SDK on
+runners). Validate manually with `rocminfo` and `hipcc` on the WSL host.
+
+The role installs `~/.config/rocm/wsl-env.sh` and sources it from both
+`~/.bashrc` and `~/.profile` for the configured `rocm_setup_user`, so new
+interactive and login shells pick up `PATH`, `LD_LIBRARY_PATH`, and
+`HSA_ENABLE_DXG_DETECTION` without manual `source`.
+
+When `rocm_setup_run_checks` is true (default), the role runs `rocminfo` after
+ROCDXG setup. On `rocdxg` hosts, set `rocm_setup_wsl_run_hip_check: true`
+(default) to also compile and run the bundled HIP hello-world test using the
+same `wsl-env.sh` path as interactive shells. Set it to `false` to skip the
+HIP compile/run step (for example on hosts without a usable GPU at playbook
+time).
 
 ## Version Management
 
@@ -229,3 +325,6 @@ author, licensing and other details.
 [ref-instinct]: https://www.amd.com/en/products/accelerators/instinct.html
 [ref-install]: https://rocm.docs.amd.com/projects/install-on-linux/en/latest/index.html
 [ref-wsl]: https://learn.microsoft.com/en-us/windows/wsl/install
+[ref-wsl-rocdxg]: https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installryz/wsl/howto_wsl.html
+[ref-librocdxg]: https://github.com/ROCm/librocdxg
+[ref-win-sdk]: https://developer.microsoft.com/windows/downloads/windows-sdk/

--- a/roles/rocm_setup/defaults/main.yml
+++ b/roles/rocm_setup/defaults/main.yml
@@ -40,8 +40,26 @@ rocm_setup_install_kernel_driver: true
 # linux-image-*-aw only.
 rocm_setup_extra_kernel_packages: []
 
-# State if this is a Windows Subsystem for Linux (WSL) install or not.
+# WSL install mode: false (Linux), legacy (roc4wsl), or rocdxg (librocdxg).
+rocm_setup_wsl: false
+
+# Deprecated: true maps to legacy when rocm_setup_wsl is false.
 rocm_setup_wsl_install: false
+
+# ROCDXG (rocm_setup_wsl: rocdxg) settings.
+rocm_setup_wsl_librocdxg_repo: https://github.com/ROCm/librocdxg.git
+rocm_setup_wsl_librocdxg_version: develop
+rocm_setup_wsl_librocdxg_src_dir: /usr/local/src/librocdxg
+rocm_setup_wsl_win_sdk_path: ""
+rocm_setup_wsl_install_win_sdk: true
+rocm_setup_wsl_win_sdk_winget_id: Microsoft.WindowsSDK.10.0.26100
+rocm_setup_wsl_hsa_enable_dxg_detection: true
+rocm_setup_wsl_hsa_override_gfx_version: ""
+rocm_setup_wsl_librocdxg_force: false
+
+# Run rocminfo when rocm_setup_run_checks is true (skipped for legacy WSL).
+# For rocdxg, optionally compile and run the HIP hello-world test too.
+rocm_setup_wsl_run_hip_check: true
 
 # Run ROCm checks (rocminfo and HIP compilation)
 # Set to false in CI or when no AMD GPUs are present

--- a/roles/rocm_setup/files/hip-hello-world.cpp
+++ b/roles/rocm_setup/files/hip-hello-world.cpp
@@ -12,7 +12,12 @@ int main() {
     hello_world_kernel<<<1, 1>>>();
 
     // Synchronize to make sure the kernel has finished executing before exiting
-    hipDeviceSynchronize();
+    hipError_t err = hipDeviceSynchronize();
+    if (err != hipSuccess) {
+        std::cerr << "hipDeviceSynchronize failed: "
+                  << hipGetErrorString(err) << std::endl;
+        return 1;
+    }
 
     // Print a confirmation from the host (CPU)
     std::cout << "Kernel execution finished." << std::endl;

--- a/roles/rocm_setup/hosts-rocm-setup
+++ b/roles/rocm_setup/hosts-rocm-setup
@@ -3,12 +3,18 @@ rocm_servers:
     snoc-think-vm:
         ansible_host: snoc-think
         ansible_port: 2222
-    stebates-amd-laptop:
+    stebates-amd-laptop-legacy:
         ansible_connection: local
-        rocm_setup_wsl_install: true
+        rocm_setup_wsl: legacy
         rocm_setup_rocm_version: 6.4.4
         rocm_setup_amdgpu_version: "{{ rocm_setup_rocm_version }}"
         rocm_setup_version_force: true
+    stebates-amd-laptop-rocdxg:
+        ansible_connection: local
+        rocm_setup_wsl: rocdxg
+        rocm_setup_rocm_version: "7.2"
+        rocm_setup_install_metrics_exporter: false
+        rocm_setup_run_checks: true
   vars:
     ansible_user: stebates
     rocm_setup_user: "{{ ansible_user }}"

--- a/roles/rocm_setup/tasks/main.yml
+++ b/roles/rocm_setup/tasks/main.yml
@@ -13,6 +13,21 @@
   vars:
     calling_role_path: "{{ rocm_setup_calling_role_path_fact }}"  # noqa var-naming
 
+- name: Resolve WSL install mode
+  ansible.builtin.set_fact:
+    rocm_setup_wsl_mode: >-
+      {{
+        'legacy' if (rocm_setup_wsl_install | default(false)
+                     and rocm_setup_wsl | default(false) in [false, none, ''])
+        else rocm_setup_wsl | default(false)
+      }}
+    rocm_setup_wsl_enabled: >-
+      {{
+        ('legacy' if (rocm_setup_wsl_install | default(false)
+                       and rocm_setup_wsl | default(false) in [false, none, ''])
+         else rocm_setup_wsl | default(false)) in ['legacy', 'rocdxg']
+      }}
+
 - name: Run the rocm_setup prerequisite steps
   ansible.builtin.import_tasks:
     file: rocm_pre.yml
@@ -77,9 +92,10 @@
     rocm_setup_packages: >-
       {{
         ['libstdc++-14-dev']
-        + ([rocm_setup_rocm_meta_pkg] if not rocm_setup_wsl_install else [])
+        + ([rocm_setup_rocm_meta_pkg]
+           if rocm_setup_wsl_mode in [false, 'rocdxg'] else [])
         + (['hsa-runtime-rocr4wsl-amdgpu', 'rocm-core', 'rocm-dev']
-           if rocm_setup_wsl_install else [])
+           if rocm_setup_wsl_mode == 'legacy' else [])
       }}
 
 - name: Install ROCm packages
@@ -129,7 +145,7 @@
       - amdgpu-dkms
     state: latest
   when:
-    - not rocm_setup_wsl_install
+    - not rocm_setup_wsl_enabled
     - rocm_setup_install_kernel_driver
   become: true
   register: rocm_setup_amdgpu_dkms_install
@@ -139,7 +155,7 @@
 - name: Display amdgpu-dkms version installed
   ansible.builtin.debug:
     msg: "amdgpu-dkms has been installed/upgraded"
-  when: not rocm_setup_wsl_install and rocm_setup_amdgpu_dkms_install.changed
+  when: not rocm_setup_wsl_enabled and rocm_setup_amdgpu_dkms_install.changed
 
 - name: Perform a reboot to allow changes to take effect
   ansible.builtin.reboot:
@@ -147,8 +163,13 @@
   become: true
   when:
     - ansible_connection != 'local'
-    - not rocm_setup_wsl_install
+    - not rocm_setup_wsl_enabled
     - not rocm_setup_skip_reboot
+
+- name: Install ROCDXG WSL bridge and environment
+  ansible.builtin.import_tasks:
+    file: rocm_rocdxg.yml
+  when: rocm_setup_wsl_mode == 'rocdxg'
 
 - name: Run the rocm checks to ensure install worked
   ansible.builtin.import_tasks:
@@ -158,4 +179,6 @@
 - name: Install and configure AMD Device Metrics Exporter
   ansible.builtin.import_tasks:
     file: metrics_exporter.yml
-  when: rocm_setup_install_metrics_exporter
+  when:
+    - rocm_setup_install_metrics_exporter
+    - not rocm_setup_wsl_enabled

--- a/roles/rocm_setup/tasks/rocm_check.yml
+++ b/roles/rocm_setup/tasks/rocm_check.yml
@@ -1,19 +1,64 @@
-- name: Check that rocminfo works
+- name: Validate ROCm installation with rocminfo
   ansible.builtin.shell:
-    cmd: rocminfo
+    cmd: |
+      set -o pipefail
+      {% if rocm_setup_wsl_mode == 'rocdxg' %}
+      if [ -f "$HOME/.config/rocm/wsl-env.sh" ]; then
+        set -a
+        . "$HOME/.config/rocm/wsl-env.sh"
+        set +a
+      fi
+      {% endif %}
+      rocminfo
+    executable: /bin/bash
+  become: "{{ rocm_setup_wsl_mode == 'rocdxg' }}"
+  become_user: "{{ rocm_setup_user if rocm_setup_wsl_mode == 'rocdxg' else omit }}"
   changed_when: false
-  when: not rocm_setup_wsl_install
+  when: rocm_setup_wsl_mode != 'legacy'
 
 - name: Copy test HIP program to target
   ansible.builtin.copy:
     src: ./files/hip-hello-world.cpp
-    dest: /tmp/
+    dest: /tmp/hip-hello-world.cpp
     owner: "{{ rocm_setup_user }}"
     group: "{{ rocm_setup_user }}"
     mode: '0644'
   become: true
+  when:
+    - rocm_setup_wsl_mode != 'legacy'
+    - rocm_setup_wsl_mode != 'rocdxg' or rocm_setup_wsl_run_hip_check | default(true)
 
-- name: Check that we can compile a very simple program
+- name: Compile and run HIP hello-world check
   ansible.builtin.shell:
-    cmd: hipcc -o /tmp/hip-hello-world /tmp/hip-hello-world.cpp
+    cmd: |
+      set -o pipefail
+      {% if rocm_setup_wsl_mode == 'rocdxg' %}
+      if [ -f "$HOME/.config/rocm/wsl-env.sh" ]; then
+        set -a
+        . "$HOME/.config/rocm/wsl-env.sh"
+        set +a
+      fi
+      {% endif %}
+      hipcc -o /tmp/hip-hello-world /tmp/hip-hello-world.cpp
+      /tmp/hip-hello-world
+    executable: /bin/bash
+  become: "{{ rocm_setup_wsl_mode == 'rocdxg' }}"
+  become_user: "{{ rocm_setup_user if rocm_setup_wsl_mode == 'rocdxg' else omit }}"
+  register: rocm_setup_hip_check
   changed_when: false
+  when:
+    - rocm_setup_wsl_mode != 'legacy'
+    - rocm_setup_wsl_mode != 'rocdxg' or rocm_setup_wsl_run_hip_check | default(true)
+
+- name: Confirm HIP hello-world ran on the GPU
+  ansible.builtin.assert:
+    that:
+      - "'Hello, World from GPU!' in rocm_setup_hip_check.stdout"
+      - "'Kernel execution finished.' in rocm_setup_hip_check.stdout"
+    fail_msg: >-
+      HIP hello-world did not report successful GPU execution. Output was:
+      {{ rocm_setup_hip_check.stdout | default('') }}
+      {{ rocm_setup_hip_check.stderr | default('') }}
+  when:
+    - rocm_setup_hip_check is defined
+    - not rocm_setup_hip_check.skipped | default(false)

--- a/roles/rocm_setup/tasks/rocm_pre.yml
+++ b/roles/rocm_setup/tasks/rocm_pre.yml
@@ -1,16 +1,18 @@
-- name: Check if wslinfo works if rocm_setup_wsl_install is set
+- name: Check if wslinfo works for legacy WSL install
   ansible.builtin.command:
     cmd: wslinfo --version
   register: wslinfo
   changed_when: false
   failed_when: false
-  when: rocm_setup_wsl_install
+  when: rocm_setup_wsl_mode == 'legacy'
 
-- name: Check if wslinfo works if rocm_setup_wsl_install is set
+- name: Fail when wslinfo is unavailable for legacy WSL install
   ansible.builtin.fail:
     msg: |
-      "wslinfo not working. WSL install requested. Aborting!"
-  when: wslinfo.rc | default(0) != 0 and rocm_setup_wsl_install
+      "wslinfo not working. Legacy WSL install requested. Aborting!"
+  when:
+    - rocm_setup_wsl_mode == 'legacy'
+    - wslinfo.rc | default(0) != 0
 
 - name: Copy the rocm-latest script to the host
   ansible.builtin.copy:
@@ -27,12 +29,12 @@
       {{ rocm_setup_rocm_version == 'latest' }}
     rocm_setup_need_amdgpu_latest: >-
       {{
-        (not rocm_setup_wsl_install)
+        (rocm_setup_wsl_mode != 'legacy')
         and (rocm_setup_amdgpu_version == 'latest')
       }}
     rocm_setup_need_graphics_latest: >-
       {{
-        (not rocm_setup_wsl_install)
+        (not rocm_setup_wsl_enabled)
         and (rocm_setup_graphics_version == 'latest')
       }}
     rocm_setup_need_metrics_exporter_latest: >-
@@ -51,9 +53,9 @@
   changed_when: false
   when:
     - rocm_setup_need_rocm_latest
-    - not rocm_setup_wsl_install
+    - rocm_setup_wsl_mode != 'legacy'
 
-- name: Run the rocm-latest script and register results (wsl)
+- name: Run the rocm-latest script and register results (legacy wsl)
   ansible.builtin.command:
     cmd: rocm-latest
   environment:
@@ -64,7 +66,7 @@
   changed_when: false
   when:
     - rocm_setup_need_rocm_latest
-    - rocm_setup_wsl_install
+    - rocm_setup_wsl_mode == 'legacy'
 
 - name: Run the rocm-latest script and register results
   ansible.builtin.command:
@@ -101,14 +103,14 @@
     msg: "rocm latest_version: {{ rocm_latest_version.stdout }}"
   when:
     - rocm_setup_need_rocm_latest
-    - not rocm_setup_wsl_install
+    - rocm_setup_wsl_mode != 'legacy'
 
-- name: Print the rocm package version (wsl)
+- name: Print the rocm package version (legacy wsl)
   ansible.builtin.debug:
     msg: "rocm latest_wsl_version: {{ rocm_latest_wsl_version.stdout }}"
   when:
     - rocm_setup_need_rocm_latest
-    - rocm_setup_wsl_install
+    - rocm_setup_wsl_mode == 'legacy'
 
 - name: Print the amdgpu package version
   ansible.builtin.debug:
@@ -129,27 +131,37 @@
 - name: Populate rocm_setup_rocm_version variable
   ansible.builtin.set_fact:
     rocm_setup_rocm_version: "{{ rocm_latest_version.stdout }}"
-  when: rocm_setup_rocm_version == 'latest' and not rocm_setup_wsl_install
+  when:
+    - rocm_setup_rocm_version == 'latest'
+    - rocm_setup_wsl_mode != 'legacy'
 
-- name: Populate rocm_setup_rocm_version variable (wsl)
+- name: Populate rocm_setup_rocm_version variable (legacy wsl)
   ansible.builtin.set_fact:
     rocm_setup_rocm_version: "{{ rocm_latest_wsl_version.stdout }}"
-  when: rocm_setup_rocm_version == 'latest' and rocm_setup_wsl_install
+  when:
+    - rocm_setup_rocm_version == 'latest'
+    - rocm_setup_wsl_mode == 'legacy'
 
 - name: Populate rocm_setup_amdgpu_version variable
   ansible.builtin.set_fact:
     rocm_setup_amdgpu_version: "{{ amdgpu_latest_version.stdout }}"
-  when: rocm_setup_amdgpu_version == 'latest' and not rocm_setup_wsl_install
+  when:
+    - rocm_setup_amdgpu_version == 'latest'
+    - rocm_setup_wsl_mode != 'legacy'
 
-- name: Populate rocm_setup_amdgpu_version variable (wsl)
+- name: Populate rocm_setup_amdgpu_version variable (legacy wsl)
   ansible.builtin.set_fact:
     rocm_setup_amdgpu_version: "{{ rocm_setup_rocm_version }}"
-  when: rocm_setup_amdgpu_version == 'latest' and rocm_setup_wsl_install
+  when:
+    - rocm_setup_amdgpu_version == 'latest'
+    - rocm_setup_wsl_mode == 'legacy'
 
 - name: Populate rocm_setup_graphics_version variable
   ansible.builtin.set_fact:
     rocm_setup_graphics_version: "{{ graphics_latest_version.stdout }}"
-  when: rocm_setup_graphics_version == 'latest' and not rocm_setup_wsl_install
+  when:
+    - rocm_setup_graphics_version == 'latest'
+    - not rocm_setup_wsl_enabled
 
 - name: Populate rocm_setup_metrics_exporter_version variable
   ansible.builtin.set_fact:
@@ -164,15 +176,15 @@
     msg: "You are not requesting the latest rocm version!"
   when:
     - rocm_setup_need_rocm_latest
-    - not rocm_setup_wsl_install
+    - rocm_setup_wsl_mode != 'legacy'
     - rocm_latest_version.stdout != rocm_setup_rocm_version
 
-- name: Fail if rocm_latest_wsl_version does not match rocm_setup_version (wsl)
+- name: Fail if rocm_latest_wsl_version does not match rocm_setup_version (legacy wsl)
   ansible.builtin.fail:
     msg: "You are not requesting the latest rocm version!"
   when:
     - rocm_setup_need_rocm_latest
-    - rocm_setup_wsl_install
+    - rocm_setup_wsl_mode == 'legacy'
     - rocm_latest_wsl_version.stdout | default('none') != rocm_setup_rocm_version
 
 - name: Fail if amdgpu_latest_version does not match rocm_setup_amdgpu_version
@@ -229,7 +241,7 @@
   become: true
   when:
     - ansible_connection != 'local'
-    - not rocm_setup_wsl_install
+    - not rocm_setup_wsl_enabled
     - not rocm_setup_skip_reboot
 
 - name: Update ansible_kernel as it may have changed
@@ -251,7 +263,7 @@
   register: rocm_setup_modules_extra_check
   changed_when: false
   failed_when: false
-  when: not rocm_setup_wsl_install
+  when: not rocm_setup_wsl_enabled
 
 - name: Install the kernel header and extra modules
   ansible.builtin.package:
@@ -263,7 +275,7 @@
             else []) }}
   become: true
   when:
-    - not rocm_setup_wsl_install
+    - not rocm_setup_wsl_enabled
     - rocm_setup_install_kernel_driver
 
 - name: Ensure the video and render groups exist

--- a/roles/rocm_setup/tasks/rocm_rocdxg.yml
+++ b/roles/rocm_setup/tasks/rocm_rocdxg.yml
@@ -1,0 +1,253 @@
+---
+# ROCDXG (librocdxg) setup for WSL2 HIP compute.
+
+- name: Assert /dev/dxg is present for ROCDXG
+  ansible.builtin.stat:
+    path: /dev/dxg
+  register: rocm_setup_wsl_dxg_device
+
+- name: Fail when /dev/dxg is missing
+  ansible.builtin.fail:
+    msg: >-
+      /dev/dxg is not available. Install Adrenalin 26.2.2+ on Windows and
+      ensure WSL2 GPU support is enabled before using rocm_setup_wsl: rocdxg.
+  when: not rocm_setup_wsl_dxg_device.stat.exists
+
+- name: Assert libdxcore.so is present for ROCDXG
+  ansible.builtin.stat:
+    path: /usr/lib/wsl/lib/libdxcore.so
+  register: rocm_setup_wsl_libdxcore
+
+- name: Fail when libdxcore.so is missing
+  ansible.builtin.fail:
+    msg: >-
+      /usr/lib/wsl/lib/libdxcore.so is not available. This host does not
+      appear to be a WSL2 environment with DXCore GPU support.
+  when: not rocm_setup_wsl_libdxcore.stat.exists
+
+- name: Check whether Windows SDK include path is already present
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      for base in \
+        "/mnt/c/Program Files (x86)/Windows Kits/10/Include" \
+        "/mnt/c/Program Files/Windows Kits/10/Include"; do
+        if [ -d "$base" ]; then
+          find "$base" -maxdepth 1 -type d -name '10.0.*' 2>/dev/null
+        fi
+      done | sort -V | tail -n 1
+    executable: /bin/bash
+  register: rocm_setup_wsl_win_sdk_precheck
+  changed_when: false
+  when: rocm_setup_wsl_win_sdk_path | default('') | length == 0
+
+- name: Install Windows SDK on the Windows host via winget
+  ansible.builtin.command:
+    argv:
+      - powershell.exe
+      - -NoProfile
+      - -NonInteractive
+      - -Command
+      - >-
+        winget install --id {{ rocm_setup_wsl_win_sdk_winget_id }}
+        --accept-package-agreements --accept-source-agreements
+        --disable-interactivity
+  register: rocm_setup_wsl_win_sdk_winget
+  changed_when: >-
+    'Successfully installed' in (rocm_setup_wsl_win_sdk_winget.stdout | default(''))
+    or 'Successfully installed' in (rocm_setup_wsl_win_sdk_winget.stderr | default(''))
+  failed_when: false
+  when:
+    - rocm_setup_wsl_install_win_sdk | default(true)
+    - rocm_setup_wsl_win_sdk_path | default('') | length == 0
+    - rocm_setup_wsl_win_sdk_precheck.stdout | trim | length == 0
+
+- name: Report Windows SDK winget install result
+  ansible.builtin.debug:
+    msg: >-
+      winget install {{ rocm_setup_wsl_win_sdk_winget_id }}:
+      {{ rocm_setup_wsl_win_sdk_winget.stdout | default('') }}
+      {{ rocm_setup_wsl_win_sdk_winget.stderr | default('') }}
+  when:
+    - rocm_setup_wsl_win_sdk_winget is defined
+    - not rocm_setup_wsl_win_sdk_winget.skipped | default(false)
+    - rocm_setup_wsl_win_sdk_winget is changed
+      or (rocm_setup_wsl_win_sdk_winget.rc | default(0)) != 0
+
+- name: Search for Windows SDK include path
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      for base in \
+        "/mnt/c/Program Files (x86)/Windows Kits/10/Include" \
+        "/mnt/c/Program Files/Windows Kits/10/Include"; do
+        if [ -d "$base" ]; then
+          find "$base" -maxdepth 1 -type d -name '10.0.*' 2>/dev/null
+        fi
+      done | sort -V | tail -n 1
+    executable: /bin/bash
+  register: rocm_setup_wsl_win_sdk_shell
+  changed_when: false
+  when: rocm_setup_wsl_win_sdk_path | default('') | length == 0
+
+- name: Set Windows SDK include path from search
+  ansible.builtin.set_fact:
+    rocm_setup_wsl_win_sdk_include: "{{ rocm_setup_wsl_win_sdk_shell.stdout | trim }}"
+  when: rocm_setup_wsl_win_sdk_path | default('') | length == 0
+
+- name: Use configured Windows SDK include path
+  ansible.builtin.set_fact:
+    rocm_setup_wsl_win_sdk_include: "{{ rocm_setup_wsl_win_sdk_path | trim }}"
+  when: rocm_setup_wsl_win_sdk_path | default('') | length > 0
+
+- name: Fail when Windows SDK include path is not found
+  ansible.builtin.fail:
+    msg: >-
+      Windows SDK include path not found under /mnt/c/Program Files/Windows
+      Kits/10/Include or /mnt/c/Program Files (x86)/Windows Kits/10/Include.
+      Install the SDK on the Windows host (elevated PowerShell):
+      winget install {{ rocm_setup_wsl_win_sdk_winget_id }}
+      --accept-package-agreements --accept-source-agreements
+      Or download from https://developer.microsoft.com/windows/downloads/windows-sdk/
+      Then re-run the playbook, or set rocm_setup_wsl_win_sdk_path in inventory
+      to the Include/10.0.x.x directory. Set
+      rocm_setup_wsl_install_win_sdk: false to skip automatic winget install.
+  when: rocm_setup_wsl_win_sdk_include | default('') | length == 0
+
+- name: Install librocdxg build dependencies
+  ansible.builtin.package:
+    name:
+      - build-essential
+      - cmake
+      - git
+    state: present
+    update_cache: true
+  become: true
+
+- name: Check if librocdxg is already installed
+  ansible.builtin.find:
+    paths:
+      - /opt/rocm/lib
+      - /opt/rocm/lib64
+    patterns:
+      - librocdxg.so*
+    file_type: file
+  register: rocm_setup_wsl_librocdxg_find
+
+- name: Set librocdxg installed fact
+  ansible.builtin.set_fact:
+    rocm_setup_wsl_librocdxg_installed: >-
+      {{ (rocm_setup_wsl_librocdxg_find.files | default([]) | length) > 0 }}
+
+- name: Clone librocdxg repository
+  ansible.builtin.git:
+    repo: "{{ rocm_setup_wsl_librocdxg_repo }}"
+    dest: "{{ rocm_setup_wsl_librocdxg_src_dir }}"
+    version: "{{ rocm_setup_wsl_librocdxg_version }}"
+    force: "{{ rocm_setup_wsl_librocdxg_force }}"
+  become: true
+  when: >-
+    rocm_setup_wsl_librocdxg_force
+    or not rocm_setup_wsl_librocdxg_installed
+
+- name: Remove stale librocdxg build directory
+  ansible.builtin.file:
+    path: "{{ rocm_setup_wsl_librocdxg_src_dir }}/build"
+    state: absent
+  become: true
+  when: >-
+    rocm_setup_wsl_librocdxg_force
+    or not rocm_setup_wsl_librocdxg_installed
+
+- name: Build and install librocdxg
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      set -e
+      mkdir -p build
+      cd build
+      cmake .. -DWIN_SDK="{{ rocm_setup_wsl_win_sdk_include }}/shared"
+      make -j"$(nproc)"
+      make install
+    chdir: "{{ rocm_setup_wsl_librocdxg_src_dir }}"
+    executable: /bin/bash
+  become: true
+  register: rocm_setup_wsl_librocdxg_build
+  changed_when: >-
+    rocm_setup_wsl_librocdxg_force | bool
+    or not rocm_setup_wsl_librocdxg_installed | bool
+  when: >-
+    rocm_setup_wsl_librocdxg_force
+    or not rocm_setup_wsl_librocdxg_installed
+
+- name: Verify librocdxg library was installed
+  ansible.builtin.find:
+    paths:
+      - /opt/rocm/lib
+      - /opt/rocm/lib64
+    patterns:
+      - librocdxg.so*
+    file_type: file
+  register: rocm_setup_wsl_librocdxg_verify
+
+- name: Fail when librocdxg library is missing after build
+  ansible.builtin.fail:
+    msg: >-
+      librocdxg build finished but no librocdxg.so was found under
+      /opt/rocm/lib or /opt/rocm/lib64. Check build output in
+      {{ rocm_setup_wsl_librocdxg_src_dir }}/build and re-run with
+      rocm_setup_wsl_librocdxg_force: true.
+  when: rocm_setup_wsl_librocdxg_verify.files | default([]) | length == 0
+
+- name: Determine if HSA_ENABLE_DXG_DETECTION is required
+  ansible.builtin.set_fact:
+    rocm_setup_wsl_needs_dxg_detection: >-
+      {{
+        rocm_setup_wsl_hsa_enable_dxg_detection
+        and (rocm_setup_rocm_version | string) is version('7.13', '<')
+      }}
+
+- name: Look up rocm_setup user home directory
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ rocm_setup_user }}"
+
+- name: Set rocm_setup user home directory fact
+  ansible.builtin.set_fact:
+    rocm_setup_wsl_user_home: "{{ ansible_facts.getent_passwd[rocm_setup_user][4] }}"
+
+- name: Ensure ROCm config directory exists for user
+  ansible.builtin.file:
+    path: "{{ rocm_setup_wsl_user_home }}/.config/rocm"
+    state: directory
+    owner: "{{ rocm_setup_user }}"
+    mode: '0755'
+  become: true
+
+- name: Install ROCDXG environment script for user
+  ansible.builtin.template:
+    src: rocm-wsl-env.sh.j2
+    dest: "{{ rocm_setup_wsl_user_home }}/.config/rocm/wsl-env.sh"
+    owner: "{{ rocm_setup_user }}"
+    mode: '0644'
+  become: true
+
+- name: Source ROCDXG environment from user shell startup files
+  ansible.builtin.blockinfile:
+    path: "{{ rocm_setup_wsl_shell_file }}"
+    marker_begin: BEGIN (rocm_setup wsl)
+    marker_end: END (rocm_setup wsl)
+    block: |
+      if [ -f "$HOME/.config/rocm/wsl-env.sh" ]; then
+        . "$HOME/.config/rocm/wsl-env.sh"
+      fi
+    create: true
+    owner: "{{ rocm_setup_user }}"
+    mode: '0644'
+  become: true
+  loop:
+    - "{{ rocm_setup_wsl_user_home }}/.bashrc"
+    - "{{ rocm_setup_wsl_user_home }}/.profile"
+  loop_control:
+    loop_var: rocm_setup_wsl_shell_file
+    label: "{{ rocm_setup_wsl_shell_file }}"

--- a/roles/rocm_setup/templates/rocm-wsl-env.sh.j2
+++ b/roles/rocm_setup/templates/rocm-wsl-env.sh.j2
@@ -1,0 +1,11 @@
+# ROCm WSL (ROCDXG) environment for {{ rocm_setup_user }}
+# Managed by Ansible rocm_setup role.
+
+{% if rocm_setup_wsl_needs_dxg_detection | default(false) %}
+export HSA_ENABLE_DXG_DETECTION=1
+{% endif %}
+{% if rocm_setup_wsl_hsa_override_gfx_version | default('') | length > 0 %}
+export HSA_OVERRIDE_GFX_VERSION={{ rocm_setup_wsl_hsa_override_gfx_version }}
+{% endif %}
+export PATH=/opt/rocm/bin:${PATH}
+export LD_LIBRARY_PATH=/opt/rocm/lib:/opt/rocm/lib64:/usr/lib/wsl/lib:${LD_LIBRARY_PATH:-}

--- a/roles/rocm_setup/templates/rocm.sources.j2
+++ b/roles/rocm_setup/templates/rocm.sources.j2
@@ -6,7 +6,7 @@ Components: main
 Architectures: amd64
 Signed-By: /etc/apt/keyrings/rocm.gpg
 
-{% if not rocm_setup_wsl_install %}
+{% if not rocm_setup_wsl_enabled %}
 Types: deb
 URIs: https://repo.radeon.com/graphics/{{ rocm_setup_graphics_version }}/ubuntu
 Suites: {{ ansible_distribution_release }}
@@ -15,7 +15,7 @@ Architectures: amd64
 Signed-By: /etc/apt/keyrings/rocm.gpg
 
 {% endif %}
-{% if rocm_setup_install_metrics_exporter %}
+{% if rocm_setup_install_metrics_exporter and not rocm_setup_wsl_enabled %}
 Types: deb
 URIs: {{ rocm_setup_metrics_exporter_repo_uri }}
 Suites: {{ ansible_distribution_release }}


### PR DESCRIPTION
Add rocm_setup_wsl (false | legacy | rocdxg) for WSL2 HIP compute using AMD's librocdxg path. The rocdxg mode installs standard ROCm packages, optionally installs the Windows SDK via winget from WSL, builds and installs librocdxg, and configures persistent ROCDXG environment variables through ~/.config/rocm/wsl-env.sh sourced from .bashrc and .profile.

Also wire optional post-install validation: rocminfo for non-legacy WSL, and rocm_setup_wsl_run_hip_check to compile and run the bundled HIP hello-world test using the same wsl-env path as interactive shells. Legacy roc4wsl installs remain available via rocm_setup_wsl: legacy or the deprecated rocm_setup_wsl_install alias.

Update CI to use rocm_setup_wsl: legacy in matrix jobs, document WSL modes in the rocm_setup README, and refresh example inventory.

Collection version: 1.3.0 -> 1.4.0.