### PR TITLE
run-ansible: auto-install local collection; fix uprof_setup CLI

### DIFF
--- a/.github/workflows/batesste-ansible-ci.yml
+++ b/.github/workflows/batesste-ansible-ci.yml
@@ -1,5 +1,5 @@
 # Main CI workflow for batesste-ansible repository
-# 
+#
 # This workflow runs linting, spelling checks, and core playbook tests.
 # Individual role tests are in separate auto-generated workflow files.
 # See .github/README.md for details on the automated workflow system.

--- a/README.md
+++ b/README.md
@@ -76,11 +76,22 @@ ansible-galaxy collection install -r requirements.yml
 
 ### Local Collection Install
 
-To install the collection from your local checkout:
+Roles included from playbooks use short names from `roles/`, but internal
+`include_role` calls use the collection FQCN (for example
+`sbates130272.batesste.check_platform`). `playbooks/run-ansible` installs the
+local collection automatically when it is missing. To rebuild and reinstall from
+your checkout after role changes, set `FORCE_LOCAL=1`:
 
 ```
+FORCE_LOCAL=1 playbooks/run-ansible
+```
+
+Manual install (same steps `run-ansible` runs):
+
+```
+ansible-galaxy collection install -r requirements.yml -p collections
 ansible-galaxy collection build --force
-ansible-galaxy collection install sbates130272-batesste-*.tar.gz --force
+ansible-galaxy collection install sbates130272-batesste-*.tar.gz --force -p collections
 ```
 
 ## Example Usage
@@ -209,12 +220,13 @@ need vault or a sudo password file on disk, set
 
 There is a simple bash script at `playbooks/run-ansible` that can call
 `ansible-playbook` for you. It sets `ANSIBLE_ROLES_PATH` to this checkout's
-`roles/` directory by default so setup playbooks use local role sources instead
-of the installed collection. By default it expects `vault-password` and
-`sudo-password` in the `playbooks/` directory. To omit the vault file (for
-example when no vault is used), set `RUN_ANSIBLE_NO_VAULT=1`. To omit the become
-password file (for example when sudo is passwordless), set
-`RUN_ANSIBLE_NO_SUDO_PASS=1`.
+`roles/` directory and ensures the local `sbates130272.batesste` collection is
+installed under `collections/` (see **Local Collection Install**). Set
+`FORCE_LOCAL=1` to rebuild and reinstall that collection from the checkout
+before each run. By default it expects `vault-password` and `sudo-password` in
+the `playbooks/` directory. To omit the vault file (for example when no vault
+is used), set `RUN_ANSIBLE_NO_VAULT=1`. To omit the become password file (for
+example when sudo is passwordless), set `RUN_ANSIBLE_NO_SUDO_PASS=1`.
 
 Otherwise you typically create:
 

--- a/playbooks/hosts.yml
+++ b/playbooks/hosts.yml
@@ -88,6 +88,8 @@ all:
           rocm_setup_run_checks: true
           rocm_setup_wsl_run_hip_check: true
           rocm_setup_install_metrics_exporter: true
+        amd-aic-vast:
+          ansible_host: amd-aic-vast
         amd-oracle:
           ansible_host: amd-oracle
           user_setup_create: false
@@ -112,25 +114,31 @@ all:
         snoc-think:
           user_setup_motd: true
         snoc-think-vm:
+          ansible_host: 10.0.0.131
+          ansible_ssh_host: 2222
           user_setup_vm_fstab: true
           user_setup_motd: true
         ibgda-brcm:
         local-vm:
           user_setup_vm_fstab: true
           user_setup_motd: true
+          rdma_setup_install_rdma_exporter: true
+          rdma_setup_motd: true
+          nvme_exporter_setup_install: true
         rocm-ernic-vm:
           ansible_host: rocm-ernic
           ansible_ssh_port: 2222
           user_setup_vm_fstab: true
           user_setup_motd: true
           rocm_setup_user: stebates
-          rocm_setup_run_checks: false
+          rocm_setup_run_checks: true
           rdma_setup_install_rdma_exporter: true
           rdma_setup_motd: true
           nvme_exporter_setup_install: true
+          uprof_setup_deb_path: /var/lib/amduprof/amduprof_5.3-518_amd64.deb
           # Forwarded exporter ports (QEMU hostfwd on host rocm-ernic)
-          # node_exporter_port: 9100
-          # nvme_exporter_port: 9998
+          #node_exporter_port: 9100
+          #nvme_exporter_port: 9998
         rocm-ernic-vm-alola:
           ansible_host: 10.7.197.12
           user_setup_vm_fstab: true

--- a/playbooks/run-ansible
+++ b/playbooks/run-ansible
@@ -15,8 +15,43 @@ TAGS=${TAGS:-}
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 REPO_ROOT=$(cd -- "${SCRIPT_DIR}/.." && pwd)
+COLLECTIONS_DIR="${REPO_ROOT}/collections"
+LOCAL_COLLECTION_MARKER="${COLLECTIONS_DIR}/ansible_collections/sbates130272/batesste/MANIFEST.json"
 ANSIBLE_ROLES_PATH=${ANSIBLE_ROLES_PATH:-"${REPO_ROOT}/roles"}
 export ANSIBLE_ROLES_PATH
+export ANSIBLE_COLLECTIONS_PATH="${COLLECTIONS_DIR}:${ANSIBLE_COLLECTIONS_PATH:-${HOME}/.ansible/collections:/usr/share/ansible/collections}"
+
+install_local_collection() {
+    mkdir -p "${COLLECTIONS_DIR}"
+
+    echo "Installing collection dependencies from requirements.yml..."
+    ansible-galaxy collection install -r "${REPO_ROOT}/requirements.yml" -p "${COLLECTIONS_DIR}"
+
+    echo "Building local sbates130272.batesste collection..."
+    (cd "${REPO_ROOT}" && ansible-galaxy collection build --force)
+
+    local tarball
+    tarball=$(ls -t "${REPO_ROOT}"/sbates130272-batesste-*.tar.gz 2>/dev/null | head -1)
+    if [ -z "${tarball}" ] || [ ! -f "${tarball}" ]; then
+        echo "Failed to find sbates130272-batesste collection tarball after build." >&2
+        exit 1
+    fi
+
+    echo "Installing ${tarball} into ${COLLECTIONS_DIR}..."
+    ansible-galaxy collection install "${tarball}" --force -p "${COLLECTIONS_DIR}"
+}
+
+ensure_local_collection() {
+    if [ "${FORCE_LOCAL:-}" = "1" ]; then
+        echo "FORCE_LOCAL=1: rebuilding local sbates130272.batesste collection..."
+        install_local_collection
+    elif [ ! -f "${LOCAL_COLLECTION_MARKER}" ]; then
+        echo "Local sbates130272.batesste collection not installed; installing from checkout..."
+        install_local_collection
+    fi
+}
+
+ensure_local_collection
 
 if [ ! -f "${HOSTS}" ]; then
     echo "${HOSTS} does not exist. Exiting!"

--- a/roles/uprof_setup/README.md
+++ b/roles/uprof_setup/README.md
@@ -13,6 +13,8 @@ time and provide its path to the role.
 - Copies the user-supplied `.deb` from the Ansible controller to
   the target host
 - Installs the package and cleans up the staged file
+- Creates a symbolic link for `AMDuProfCLI` in `/usr/local/bin`
+  (the `.deb` installs under `/opt/AMDuProf_*` only)
 - Verifies the installation by running `AMDuProfCLI --version`
 
 ## Requirements
@@ -34,6 +36,10 @@ uprof_setup_install_dir: /tmp
 
 # Skip the AMD CPU vendor check (useful for CI or non-AMD hosts).
 uprof_setup_skip_amd_check: false
+
+# Create a symbolic link for AMDuProfCLI in /usr/local/bin when
+# installed under /opt.
+uprof_setup_link_cli: true
 ```
 
 ## Dependencies

--- a/roles/uprof_setup/defaults/main.yml
+++ b/roles/uprof_setup/defaults/main.yml
@@ -16,3 +16,7 @@ uprof_setup_install_dir: /tmp
 # Skip the AMD CPU vendor check. Useful for CI runners or
 # environments where ansible_processor is unavailable.
 uprof_setup_skip_amd_check: false
+
+# Symlink AMDuProfCLI into /usr/local/bin when installed under
+# /opt/AMDuProf_* (the .deb does not add it to PATH).
+uprof_setup_link_cli: true

--- a/roles/uprof_setup/tasks/main.yml
+++ b/roles/uprof_setup/tasks/main.yml
@@ -85,9 +85,60 @@
         state: absent
       become: true
 
+- name: Locate AMDuProfCLI from the amduprof package
+  ansible.builtin.command:
+    cmd: dpkg -L amduprof
+  register: uprof_setup_package_files
+  changed_when: false
+  failed_when: false
+
+- name: Set AMDuProfCLI path from package file list
+  ansible.builtin.set_fact:
+    uprof_setup_cli_path: >-
+      {{
+        uprof_setup_package_files.stdout_lines
+        | select('match', '.*/bin/AMDuProfCLI$')
+        | list
+        | first
+        | default('', true)
+      }}
+
+- name: Locate AMDuProfCLI on PATH when not in package
+  ansible.builtin.command:
+    cmd: command -v AMDuProfCLI
+  register: uprof_setup_cli_which
+  changed_when: false
+  failed_when: false
+  when: uprof_setup_cli_path | length == 0
+
+- name: Set AMDuProfCLI path from PATH lookup
+  ansible.builtin.set_fact:
+    uprof_setup_cli_path: "{{ uprof_setup_cli_which.stdout }}"
+  when:
+    - uprof_setup_cli_path | length == 0
+    - uprof_setup_cli_which.rc == 0
+
+- name: Fail when AMDuProfCLI cannot be located
+  ansible.builtin.fail:
+    msg: >-
+      amduprof is installed but AMDuProfCLI was not found under
+      /opt/AMDuProf_*/bin/AMDuProfCLI or on PATH.
+  when: uprof_setup_cli_path | length == 0
+
+- name: Ensure AMDuProfCLI is on PATH via /usr/local/bin symlink
+  ansible.builtin.file:
+    src: "{{ uprof_setup_cli_path }}"
+    dest: /usr/local/bin/AMDuProfCLI
+    state: link
+    force: true
+  become: true
+  when:
+    - uprof_setup_link_cli | bool
+    - "'/opt/AMDuProf_' in uprof_setup_cli_path"
+
 - name: Verify AMD uProf installation
   ansible.builtin.command:
-    cmd: AMDuProfCLI --version
+    cmd: "{{ uprof_setup_cli_path }} --version"
   register: uprof_setup_version_check
   changed_when: false
 


### PR DESCRIPTION
playbooks/run-ansible now builds and installs sbates130272.batesste into collections/ when the local collection is missing, and supports FORCE_LOCAL=1 to rebuild from the checkout after role edits. Export ANSIBLE_COLLECTIONS_PATH so FQCN include_role calls resolve during playbook runs.

Fix uprof_setup verification: the amduprof .deb installs AMDuProfCLI under /opt/AMDuProf_*/bin only. Resolve the binary from dpkg -L, symlink it into /usr/local/bin (uprof_setup_link_cli, default true), and verify using the resolved path.

Document auto-install, FORCE_LOCAL=1, and manual collection install steps in README.md.