### PR TITLE
release: bump collection to 1.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,29 @@ sbates130272.batesste Release Notes
 
 .. contents:: Topics
 
+v1.5.0
+======
+
+Release Summary
+----------------
+Auto-install the local collection from
+``playbooks/run-ansible`` and fix AMD uProf CLI discovery
+after ``.deb`` install.
+
+Minor Changes
+--------------
+- ``playbooks/run-ansible`` — auto-install the local
+  ``sbates130272.batesste`` collection when missing. Set
+  ``FORCE_LOCAL=1`` to rebuild and reinstall from the
+  checkout before each run.
+
+Bugfixes
+---------
+- ``uprof_setup`` — resolve ``AMDuProfCLI`` from the
+  ``amduprof`` package under ``/opt/AMDuProf_*`` and add
+  a symbolic link in ``/usr/local/bin``; the ``.deb`` does
+  not add the CLI to PATH.
+
 v1.0.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,6 +1,25 @@
 ---
 ancestor: null
 releases:
+  1.5.0:
+    release_date: "2026-06-05"
+    changes:
+      release_summary: >-
+        Auto-install the local collection from
+        playbooks/run-ansible and fix AMD uProf CLI
+        discovery after .deb install.
+      minor_changes:
+        - >-
+          playbooks/run-ansible — auto-install the local
+          sbates130272.batesste collection when missing.
+          Set FORCE_LOCAL=1 to rebuild and reinstall from
+          the checkout before each run.
+      bugfixes:
+        - >-
+          uprof_setup — resolve AMDuProfCLI from the
+          amduprof package under /opt/AMDuProf_* and add
+          a symbolic link in /usr/local/bin; the .deb
+          does not add the CLI to PATH.
   1.0.0:
     release_date: "2026-03-19"
     changes:

--- a/changelogs/fragments/run-ansible-uprof-setup.yml
+++ b/changelogs/fragments/run-ansible-uprof-setup.yml
@@ -1,0 +1,18 @@
+---
+# Copyright (c) Stephen Bates, 2026
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+minor_changes:
+  - >-
+    playbooks/run-ansible — auto-install the local
+    sbates130272.batesste collection when missing. Set
+    FORCE_LOCAL=1 to rebuild and reinstall from the
+    checkout before each run.
+
+bugfixes:
+  - >-
+    uprof_setup — resolve AMDuProfCLI from the amduprof
+    package under /opt/AMDuProf_* and add a symbolic link
+    in /usr/local/bin; the .deb does not add the CLI to
+    PATH.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: sbates130272
 name: batesste
-version: 1.4.0
+version: 1.5.0
 readme: README.md
 
 authors:


### PR DESCRIPTION
Auto-install local collection from run-ansible (FORCE_LOCAL=1) and fix uprof_setup AMDuProfCLI discovery after .deb install.

Collection version: 1.4.0 -> 1.5.0.